### PR TITLE
Bind backend server to all interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ pip install -r requirements.txt
 ## Running the server
 
 ```bash
-uvicorn backend.server:app --reload
+uvicorn backend.server:app --host 0.0.0.0 --reload
 ```
 
 Open the browser at `http://localhost:8000` and enter the same game ID in two different windows to play against another player.

--- a/backend/server.py
+++ b/backend/server.py
@@ -67,3 +67,9 @@ async def websocket_endpoint(websocket: WebSocket, game_id: str):
     except WebSocketDisconnect:
         manager.disconnect(game_id, websocket)
 
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+


### PR DESCRIPTION
## Summary
- Run uvicorn with host 0.0.0.0 so the backend is reachable externally
- Document the new host option in the README

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688df4f7546083279f69efbbefe536f7