### PR TITLE
Serve frontend assets via FastAPI static files

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -6,10 +6,12 @@ from typing import Dict, List
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
 
 from .game import Game
 
 app = FastAPI()
+app.mount("/static", StaticFiles(directory="static"), name="static")
 
 # In-memory store of games and connections
 class ConnectionManager:

--- a/static/index.html
+++ b/static/index.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <title>Othello Online</title>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>
     <h1>Othello Online</h1>
     <div id="board"></div>
-    <script src="script.js"></script>
+    <script src="/static/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- serve JavaScript and CSS through FastAPI StaticFiles
- update index.html to reference new static file paths

## Testing
- `pytest`
- `curl -I http://localhost:8000/static/script.js`


------
https://chatgpt.com/codex/tasks/task_e_688df5e032a4832780e04091d1735e21