### PR TITLE
Display player names and restrict valid moves

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -18,12 +18,16 @@ class ConnectionManager:
     def __init__(self) -> None:
         self.active: Dict[str, List[WebSocket]] = {}
         self.games: Dict[str, Game] = {}
+        # Track player names per game. Keys are game ids and values are
+        # dictionaries mapping color ("black"/"white") to the player's name.
+        self.names: Dict[str, Dict[str, str]] = {}
 
     async def connect(self, game_id: str, websocket: WebSocket) -> str:
         await websocket.accept()
         if game_id not in self.active:
             self.active[game_id] = []
             self.games[game_id] = Game()
+            self.names[game_id] = {"black": "", "white": ""}
         players = self.active[game_id]
         players.append(websocket)
         return "black" if len(players) == 1 else "white"
@@ -35,6 +39,7 @@ class ConnectionManager:
         if not players:
             self.active.pop(game_id, None)
             self.games.pop(game_id, None)
+            self.names.pop(game_id, None)
 
     async def broadcast(self, game_id: str, message: dict) -> None:
         for connection in self.active.get(game_id, []):
@@ -54,7 +59,17 @@ async def get_index() -> HTMLResponse:
 async def websocket_endpoint(websocket: WebSocket, game_id: str):
     color = await manager.connect(game_id, websocket)
     game = manager.games[game_id]
-    await websocket.send_text(json.dumps({"type": "init", "board": game.board, "color": color, "current": game.current_player}))
+    await websocket.send_text(
+        json.dumps(
+            {
+                "type": "init",
+                "board": game.board,
+                "color": color,
+                "current": game.current_player,
+                "players": manager.names[game_id],
+            }
+        )
+    )
     try:
         while True:
             data = await websocket.receive_text()
@@ -63,9 +78,28 @@ async def websocket_endpoint(websocket: WebSocket, game_id: str):
                 x, y = msg["x"], msg["y"]
                 player = 1 if msg["color"] == "black" else -1
                 if game.current_player == player and game.make_move(x, y, player):
-                    await manager.broadcast(game_id, {"type": "update", "board": game.board, "current": game.current_player})
+                    await manager.broadcast(
+                        game_id,
+                        {
+                            "type": "update",
+                            "board": game.board,
+                            "current": game.current_player,
+                            "players": manager.names[game_id],
+                        },
+                    )
                 else:
                     await websocket.send_text(json.dumps({"type": "error", "message": "Invalid move"}))
+            elif msg.get("action") == "name":
+                # Store the player's name and inform all connected clients.
+                manager.names[game_id][color] = msg.get("name", "")
+                await manager.broadcast(
+                    game_id,
+                    {
+                        "type": "players",
+                        "players": manager.names[game_id],
+                        "current": game.current_player,
+                    },
+                )
     except WebSocketDisconnect:
         manager.disconnect(game_id, websocket)
 

--- a/static/index.html
+++ b/static/index.html
@@ -7,6 +7,10 @@
 </head>
 <body>
     <h1>Othello Online</h1>
+    <div id="players">
+        <div id="black-player" class="player">Black: <span id="black-name"></span></div>
+        <div id="white-player" class="player">White: <span id="white-name"></span></div>
+    </div>
     <div id="board"></div>
     <script src="/static/script.js"></script>
 </body>

--- a/static/script.js
+++ b/static/script.js
@@ -1,33 +1,53 @@
 let socket;
 let playerColor = null;
+let playerName = null;
 
 function connect() {
     const gameId = prompt("Enter game ID");
+    playerName = prompt("Enter your name");
     const wsUrl = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + `/ws/${gameId}`;
     socket = new WebSocket(wsUrl);
     socket.onmessage = (event) => {
         const msg = JSON.parse(event.data);
         if (msg.type === 'init') {
             playerColor = msg.color;
-            renderBoard(msg.board);
+            renderBoard(msg.board, msg.current);
+            renderPlayers(msg.players, msg.current);
+            if (playerName) {
+                socket.send(JSON.stringify({action: 'name', name: playerName}));
+            }
         } else if (msg.type === 'update') {
-            renderBoard(msg.board);
+            renderBoard(msg.board, msg.current);
+            renderPlayers(msg.players, msg.current);
+        } else if (msg.type === 'players') {
+            renderPlayers(msg.players, msg.current);
         } else if (msg.type === 'error') {
             alert(msg.message);
         }
     };
 }
 
-function renderBoard(board) {
+function renderBoard(board, current) {
     const boardDiv = document.getElementById('board');
     boardDiv.innerHTML = '';
-    board.forEach((col, x) => {
-        col.forEach((cell, y) => {
+    const turnColor = current === 1 ? 'black' : current === -1 ? 'white' : null;
+    const valid = new Set();
+    if (turnColor) {
+        validMoves(board, current).forEach(([vx, vy]) => valid.add(`${vx},${vy}`));
+    }
+    board.forEach((row, x) => {
+        row.forEach((cell, y) => {
             const cellDiv = document.createElement('div');
             cellDiv.className = 'cell';
-            cellDiv.dataset.x = x;
-            cellDiv.dataset.y = y;
-            cellDiv.onclick = () => sendMove(x, y);
+            const key = `${x},${y}`;
+            if (
+                cell === 0 &&
+                playerColor === turnColor &&
+                valid.has(key)
+            ) {
+                cellDiv.classList.add('valid');
+                cellDiv.onclick = () => sendMove(x, y);
+            }
             if (cell !== 0) {
                 const disc = document.createElement('div');
                 disc.className = 'disc ' + (cell === 1 ? 'black' : 'white');
@@ -36,6 +56,49 @@ function renderBoard(board) {
             boardDiv.appendChild(cellDiv);
         });
     });
+}
+
+function renderPlayers(players, current) {
+    document.getElementById('black-name').textContent = players.black || 'Waiting...';
+    document.getElementById('white-name').textContent = players.white || 'Waiting...';
+    document.getElementById('black-player').classList.toggle('active', current === 1);
+    document.getElementById('white-player').classList.toggle('active', current === -1);
+}
+
+function validMoves(board, player) {
+    const moves = [];
+    for (let x = 0; x < board.length; x++) {
+        for (let y = 0; y < board[x].length; y++) {
+            if (board[x][y] === 0 && captures(board, x, y, player).length > 0) {
+                moves.push([x, y]);
+            }
+        }
+    }
+    return moves;
+}
+
+function captures(board, x, y, player) {
+    const opponent = -player;
+    const captured = [];
+    const dirs = [
+        [-1, -1], [0, -1], [1, -1],
+        [-1, 0],           [1, 0],
+        [-1, 1],  [0, 1],  [1, 1]
+    ];
+    for (const [dx, dy] of dirs) {
+        let nx = x + dx;
+        let ny = y + dy;
+        const temp = [];
+        while (nx >= 0 && nx < 8 && ny >= 0 && ny < 8 && board[nx][ny] === opponent) {
+            temp.push([nx, ny]);
+            nx += dx;
+            ny += dy;
+        }
+        if (nx >= 0 && nx < 8 && ny >= 0 && ny < 8 && board[nx][ny] === player && temp.length > 0) {
+            captured.push(...temp);
+        }
+    }
+    return captured;
 }
 
 function sendMove(x, y) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -6,6 +6,22 @@ body {
     text-align: center;
 }
 
+#players {
+    margin-top: 10px;
+}
+
+.player {
+    display: inline-block;
+    margin: 0 10px;
+    padding: 5px 10px;
+    border-radius: 4px;
+    background-color: rgba(0,0,0,0.2);
+}
+
+.player.active {
+    border: 2px solid #fff;
+}
+
 #board {
     margin: 20px auto;
     width: 400px;
@@ -23,8 +39,13 @@ body {
     position: relative;
 }
 
-.cell:hover {
+.cell.valid {
     background-color: rgba(255,255,255,0.1);
+    cursor: pointer;
+}
+
+.cell.valid:hover {
+    background-color: rgba(255,255,255,0.2);
 }
 
 .disc {


### PR DESCRIPTION
## Summary
- broadcast and track player names on the websocket server
- show both player names in the UI and highlight the active player
- allow clicks only on valid moves for the current player

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ebeaf49e48327a9ae80add245e0d2