### PR TITLE
Highlight valid moves on hover and display game stats

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -8,10 +8,11 @@
 <body>
     <h1>Othello Online</h1>
     <div id="players">
-        <div id="black-player" class="player">Black: <span id="black-name"></span></div>
-        <div id="white-player" class="player">White: <span id="white-name"></span></div>
+        <div id="black-player" class="player">Black (<span id="black-count">0</span>): <span id="black-name"></span></div>
+        <div id="white-player" class="player">White (<span id="white-count">0</span>): <span id="white-name"></span></div>
     </div>
     <div id="board"></div>
+    <div id="message"></div>
     <script src="/static/script.js"></script>
 </body>
 </html>

--- a/static/script.js
+++ b/static/script.js
@@ -35,6 +35,8 @@ function renderBoard(board, current) {
     if (turnColor) {
         validMoves(board, current).forEach(([vx, vy]) => valid.add(`${vx},${vy}`));
     }
+    let blackCount = 0;
+    let whiteCount = 0;
     board.forEach((row, x) => {
         row.forEach((cell, y) => {
             const cellDiv = document.createElement('div');
@@ -52,10 +54,29 @@ function renderBoard(board, current) {
                 const disc = document.createElement('div');
                 disc.className = 'disc ' + (cell === 1 ? 'black' : 'white');
                 cellDiv.appendChild(disc);
+                if (cell === 1) {
+                    blackCount++;
+                } else if (cell === -1) {
+                    whiteCount++;
+                }
             }
             boardDiv.appendChild(cellDiv);
         });
     });
+    document.getElementById('black-count').textContent = blackCount;
+    document.getElementById('white-count').textContent = whiteCount;
+    const messageDiv = document.getElementById('message');
+    if (current === 0) {
+        if (blackCount > whiteCount) {
+            messageDiv.textContent = 'Game over! Black wins.';
+        } else if (whiteCount > blackCount) {
+            messageDiv.textContent = 'Game over! White wins.';
+        } else {
+            messageDiv.textContent = "Game over! It's a draw.";
+        }
+    } else {
+        messageDiv.textContent = '';
+    }
 }
 
 function renderPlayers(players, current) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -22,6 +22,11 @@ body {
     border: 2px solid #fff;
 }
 
+#message {
+    margin-top: 10px;
+    font-size: 1.2em;
+}
+
 #board {
     margin: 20px auto;
     width: 400px;
@@ -40,7 +45,6 @@ body {
 }
 
 .cell.valid {
-    background-color: rgba(255,255,255,0.1);
     cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- Show tile counts for each player and highlight valid moves only on hover.
- Display end-of-game message announcing the winner.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ed2d114348327b18928a2af6b5ac4