### PR TITLE
Add lobby and persistent player names

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -50,9 +50,25 @@ manager = ConnectionManager()
 
 
 @app.get("/")
-async def get_index() -> HTMLResponse:
+async def get_lobby() -> HTMLResponse:
     with open("static/index.html", "r", encoding="utf-8") as f:
         return HTMLResponse(f.read())
+
+
+@app.get("/game/{game_id}")
+async def get_game(game_id: str) -> HTMLResponse:
+    with open("static/game.html", "r", encoding="utf-8") as f:
+        return HTMLResponse(f.read())
+
+
+@app.get("/rooms")
+async def list_rooms() -> dict:
+    return {
+        "rooms": [
+            {"id": gid, "players": players}
+            for gid, players in manager.names.items()
+        ]
+    }
 
 
 @app.websocket("/ws/{game_id}")

--- a/static/game.html
+++ b/static/game.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Othello Online</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+    <h1>Othello Online</h1>
+    <div id="players">
+        <div id="black-player" class="player">Black (<span id="black-count">0</span>): <span id="black-name"></span></div>
+        <div id="white-player" class="player">White (<span id="white-count">0</span>): <span id="white-name"></span></div>
+    </div>
+    <div id="board"></div>
+    <div id="message"></div>
+    <script src="/static/script.js"></script>
+</body>
+</html>

--- a/static/index.html
+++ b/static/index.html
@@ -2,17 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Othello Online</title>
+    <title>Othello Lobby</title>
     <link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>
-    <h1>Othello Online</h1>
-    <div id="players">
-        <div id="black-player" class="player">Black (<span id="black-count">0</span>): <span id="black-name"></span></div>
-        <div id="white-player" class="player">White (<span id="white-count">0</span>): <span id="white-name"></span></div>
-    </div>
-    <div id="board"></div>
-    <div id="message"></div>
-    <script src="/static/script.js"></script>
+    <h1>Othello Lobby</h1>
+    <div id="welcome"></div>
+    <ul id="rooms"></ul>
+    <button id="create-room">Create New Room</button>
+    <script src="/static/lobby.js"></script>
 </body>
 </html>

--- a/static/lobby.js
+++ b/static/lobby.js
@@ -1,0 +1,35 @@
+let playerName = localStorage.getItem('playerName');
+if (!playerName) {
+    playerName = prompt('Enter your name');
+    if (playerName) {
+        localStorage.setItem('playerName', playerName);
+    }
+}
+if (playerName) {
+    document.getElementById('welcome').textContent = `Welcome, ${playerName}`;
+}
+
+async function fetchRooms() {
+    const res = await fetch('/rooms');
+    const data = await res.json();
+    const list = document.getElementById('rooms');
+    list.innerHTML = '';
+    data.rooms.forEach(room => {
+        const li = document.createElement('li');
+        const black = room.players.black || '---';
+        const white = room.players.white || '---';
+        li.textContent = `${room.id} (Black: ${black}, White: ${white})`;
+        li.onclick = () => {
+            window.location.href = `/game/${room.id}`;
+        };
+        list.appendChild(li);
+    });
+}
+
+setInterval(fetchRooms, 2000);
+fetchRooms();
+
+document.getElementById('create-room').onclick = () => {
+    const newId = Math.random().toString(36).substring(2, 8);
+    window.location.href = `/game/${newId}`;
+};

--- a/static/script.js
+++ b/static/script.js
@@ -1,10 +1,18 @@
 let socket;
 let playerColor = null;
-let playerName = null;
+let playerName = localStorage.getItem('playerName');
+const gameId = window.location.pathname.split('/').pop();
 
 function connect() {
-    const gameId = prompt("Enter game ID");
-    playerName = prompt("Enter your name");
+    if (!gameId) {
+        return;
+    }
+    if (!playerName) {
+        playerName = prompt('Enter your name');
+        if (playerName) {
+            localStorage.setItem('playerName', playerName);
+        }
+    }
     const wsUrl = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + `/ws/${gameId}`;
     socket = new WebSocket(wsUrl);
     socket.onmessage = (event) => {


### PR DESCRIPTION
## Summary
- Add lobby endpoint and REST API to list active game rooms
- Remember players' names and connect to games using URL paths
- Provide lobby page to join or create rooms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eea22e9f0832780cdc237cbc88212