### PR TITLE
Add persistent games, sequential room names and improved lobby

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import json
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
@@ -16,33 +16,70 @@ app.mount("/static", StaticFiles(directory="static"), name="static")
 # In-memory store of games and connections
 class ConnectionManager:
     def __init__(self) -> None:
-        self.active: Dict[str, List[WebSocket]] = {}
+        # Track active connections per game. For each game we store the
+        # websocket for the black and white player as well as any spectators.
+        self.active: Dict[str, Dict[str, object]] = {}
         self.games: Dict[str, Game] = {}
         # Track player names per game. Keys are game ids and values are
         # dictionaries mapping color ("black"/"white") to the player's name.
         self.names: Dict[str, Dict[str, str]] = {}
+        # Incremental id counter for friendly game names.
+        self.counter: int = 0
 
-    async def connect(self, game_id: str, websocket: WebSocket) -> str:
-        await websocket.accept()
+    def _init_game(self, game_id: str) -> None:
+        """Initialize data structures for a new game if it doesn't exist."""
         if game_id not in self.active:
-            self.active[game_id] = []
+            self.active[game_id] = {"black": None, "white": None, "spectators": []}
             self.games[game_id] = Game()
             self.names[game_id] = {"black": "", "white": ""}
+
+    def create_game(self) -> str:
+        """Create a new game and return its id."""
+        self.counter += 1
+        game_id = str(self.counter)
+        self._init_game(game_id)
+        return game_id
+
+    async def connect(self, game_id: str, websocket: WebSocket, requested: Optional[str] = None) -> str:
+        await websocket.accept()
+        self._init_game(game_id)
         players = self.active[game_id]
-        players.append(websocket)
-        return "black" if len(players) == 1 else "white"
+
+        # If the client requested a specific color and that slot is free, honor it.
+        if requested in ("black", "white") and players[requested] is None:
+            players[requested] = websocket
+            return requested
+
+        if players["black"] is None:
+            players["black"] = websocket
+            return "black"
+        if players["white"] is None:
+            players["white"] = websocket
+            return "white"
+
+        players["spectators"].append(websocket)
+        return "spectator"
 
     def disconnect(self, game_id: str, websocket: WebSocket) -> None:
         players = self.active.get(game_id)
-        if players and websocket in players:
-            players.remove(websocket)
         if not players:
-            self.active.pop(game_id, None)
-            self.games.pop(game_id, None)
-            self.names.pop(game_id, None)
+            return
+        if players.get("black") is websocket:
+            players["black"] = None
+        elif players.get("white") is websocket:
+            players["white"] = None
+        elif websocket in players.get("spectators", []):
+            players["spectators"].remove(websocket)
 
     async def broadcast(self, game_id: str, message: dict) -> None:
-        for connection in self.active.get(game_id, []):
+        players = self.active.get(game_id, {})
+        connections: List[WebSocket] = []
+        for key in ("black", "white"):
+            ws = players.get(key)
+            if ws is not None:
+                connections.append(ws)
+        connections.extend(players.get("spectators", []))
+        for connection in connections:
             await connection.send_text(json.dumps(message))
 
 
@@ -65,15 +102,22 @@ async def get_game(game_id: str) -> HTMLResponse:
 async def list_rooms() -> dict:
     return {
         "rooms": [
-            {"id": gid, "players": players}
+            {"id": gid, "name": f"Game {gid}", "players": players}
             for gid, players in manager.names.items()
         ]
     }
 
 
+@app.post("/create")
+async def create_room() -> dict:
+    new_id = manager.create_game()
+    return {"id": new_id}
+
+
 @app.websocket("/ws/{game_id}")
 async def websocket_endpoint(websocket: WebSocket, game_id: str):
-    color = await manager.connect(game_id, websocket)
+    requested = websocket.query_params.get("color")
+    color = await manager.connect(game_id, websocket, requested)
     game = manager.games[game_id]
     await websocket.send_text(
         json.dumps(
@@ -105,7 +149,7 @@ async def websocket_endpoint(websocket: WebSocket, game_id: str):
                     )
                 else:
                     await websocket.send_text(json.dumps({"type": "error", "message": "Invalid move"}))
-            elif msg.get("action") == "name":
+            elif msg.get("action") == "name" and color in ("black", "white"):
                 # Store the player's name and inform all connected clients.
                 manager.names[game_id][color] = msg.get("name", "")
                 await manager.broadcast(

--- a/static/lobby.js
+++ b/static/lobby.js
@@ -18,7 +18,7 @@ async function fetchRooms() {
         const li = document.createElement('li');
         const black = room.players.black || '---';
         const white = room.players.white || '---';
-        li.textContent = `${room.id} (Black: ${black}, White: ${white})`;
+        li.textContent = `${room.name} (Black: ${black}, White: ${white})`;
         li.onclick = () => {
             window.location.href = `/game/${room.id}`;
         };
@@ -29,7 +29,8 @@ async function fetchRooms() {
 setInterval(fetchRooms, 2000);
 fetchRooms();
 
-document.getElementById('create-room').onclick = () => {
-    const newId = Math.random().toString(36).substring(2, 8);
-    window.location.href = `/game/${newId}`;
+document.getElementById('create-room').onclick = async () => {
+    const res = await fetch('/create', {method: 'POST'});
+    const data = await res.json();
+    window.location.href = `/game/${data.id}`;
 };

--- a/static/styles.css
+++ b/static/styles.css
@@ -6,6 +6,43 @@ body {
     text-align: center;
 }
 
+#rooms {
+    list-style: none;
+    padding: 0;
+    margin: 20px auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 15px;
+    width: 80%;
+}
+
+#rooms li {
+    background-color: #0a3d2e;
+    border: 4px solid #654321;
+    padding: 15px;
+    box-shadow: 0 0 10px #000 inset;
+    cursor: pointer;
+}
+
+#rooms li:hover {
+    background-color: rgba(255,255,255,0.1);
+}
+
+#create-room {
+    margin-top: 20px;
+    padding: 10px 20px;
+    background-color: #654321;
+    color: #fff;
+    border: none;
+    cursor: pointer;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.5);
+}
+
+#create-room:hover {
+    background-color: #7a552a;
+}
+
 #players {
     margin-top: 10px;
 }


### PR DESCRIPTION
## Summary
- Preserve game state on disconnect and allow players to reconnect to their color
- Sequentially named games with server-side room creation
- Styled lobby to match game board aesthetics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689002d22958832798b891c0b5a257cc