### PR TITLE
Preserve game state and improve lobby

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -8,7 +8,7 @@
 <body>
     <h1>Othello Lobby</h1>
     <div id="welcome"></div>
-    <ul id="rooms"></ul>
+    <div id="rooms"></div>
     <button id="create-room">Create New Room</button>
     <script src="/static/lobby.js"></script>
 </body>

--- a/static/lobby.js
+++ b/static/lobby.js
@@ -15,21 +15,23 @@ async function fetchRooms() {
     const list = document.getElementById('rooms');
     list.innerHTML = '';
     data.rooms.forEach(room => {
-        const li = document.createElement('li');
+        const div = document.createElement('div');
+        div.className = 'room';
         const black = room.players.black || '---';
         const white = room.players.white || '---';
-        li.textContent = `${room.id} (Black: ${black}, White: ${white})`;
-        li.onclick = () => {
+        div.textContent = `${room.name} (Black: ${black}, White: ${white})`;
+        div.onclick = () => {
             window.location.href = `/game/${room.id}`;
         };
-        list.appendChild(li);
+        list.appendChild(div);
     });
 }
 
 setInterval(fetchRooms, 2000);
 fetchRooms();
 
-document.getElementById('create-room').onclick = () => {
-    const newId = Math.random().toString(36).substring(2, 8);
-    window.location.href = `/game/${newId}`;
+document.getElementById('create-room').onclick = async () => {
+    const res = await fetch('/create');
+    const room = await res.json();
+    window.location.href = `/game/${room.id}`;
 };

--- a/static/script.js
+++ b/static/script.js
@@ -13,7 +13,8 @@ function connect() {
             localStorage.setItem('playerName', playerName);
         }
     }
-    const wsUrl = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + `/ws/${gameId}`;
+    const nameParam = playerName ? `?name=${encodeURIComponent(playerName)}` : '';
+    const wsUrl = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + `/ws/${gameId}${nameParam}`;
     socket = new WebSocket(wsUrl);
     socket.onmessage = (event) => {
         const msg = JSON.parse(event.data);

--- a/static/styles.css
+++ b/static/styles.css
@@ -76,3 +76,43 @@ body {
 .disc.white {
     background: radial-gradient(circle at 30% 30%, #fff, #ccc);
 }
+
+/* Lobby styling */
+#rooms {
+    margin: 20px auto;
+    width: 400px;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 4px;
+    background-color: #0a3d2e;
+    box-shadow: 0 0 10px #000 inset;
+    border: 8px solid #654321;
+    padding: 0;
+}
+
+#rooms .room {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgba(0,0,0,0.3);
+    cursor: pointer;
+    padding: 10px;
+}
+
+#rooms .room:hover {
+    background-color: rgba(255,255,255,0.2);
+}
+
+#create-room {
+    margin-top: 20px;
+    padding: 10px 20px;
+    background-color: #654321;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+#create-room:hover {
+    background-color: #805a2c;
+}


### PR DESCRIPTION
## Summary
- Keep Othello matches alive after players disconnect and allow them to reclaim their color using their saved name
- Generate sequentially named rooms via a new API endpoint and display these friendly names in the lobby
- Restyle the lobby to match the game board, including grid-based room tiles and themed controls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689002c614d883278bca379203a23d9d