### PR TITLE
Reserve seat after player leaves game room

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -1,6 +1,7 @@
 """FastAPI WebSocket server for multiplayer Othello."""
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Dict, Optional
 
@@ -23,6 +24,8 @@ class ConnectionManager:
         # Track player names per game. Keys are game ids and values are
         # dictionaries mapping color ("black"/"white") to the player's name.
         self.names: Dict[str, Dict[str, str]] = {}
+        # Track pending tasks that release a reserved seat after a delay.
+        self.release_tasks: Dict[str, Dict[str, Optional[asyncio.Task]]] = {}
         # Human friendly room names
         self.room_names: Dict[str, str] = {}
         self._counter = 1
@@ -34,6 +37,7 @@ class ConnectionManager:
         self.active[game_id] = {"black": None, "white": None}
         self.games[game_id] = Game()
         self.names[game_id] = {"black": "", "white": ""}
+        self.release_tasks[game_id] = {"black": None, "white": None}
         self.room_names[game_id] = f"Game {game_id}"
         return game_id
 
@@ -44,6 +48,7 @@ class ConnectionManager:
             self.active[game_id] = {"black": None, "white": None}
             self.games[game_id] = Game()
             self.names[game_id] = {"black": "", "white": ""}
+            self.release_tasks[game_id] = {"black": None, "white": None}
             self.room_names.setdefault(game_id, f"Game {game_id}")
         players = self.active[game_id]
         names = self.names[game_id]
@@ -52,15 +57,20 @@ class ConnectionManager:
             color = "black"
         elif name and names.get("white") == name:
             color = "white"
-        elif players["black"] is None:
+        elif players["black"] is None and names["black"] == "":
             color = "black"
-        elif players["white"] is None:
+        elif players["white"] is None and names["white"] == "":
             color = "white"
         else:
-            # Both spots taken
+            # Both spots taken or seat reserved
             await websocket.close()
             raise WebSocketDisconnect()
         players[color] = websocket
+        # Cancel any pending release task for this seat
+        task = self.release_tasks.get(game_id, {}).get(color)
+        if task:
+            task.cancel()
+            self.release_tasks[game_id][color] = None
         return color
 
     def disconnect(self, game_id: str, websocket: WebSocket) -> None:
@@ -70,6 +80,25 @@ class ConnectionManager:
         for color, ws in players.items():
             if ws is websocket:
                 players[color] = None
+                # Schedule seat release after 60 seconds
+                existing = self.release_tasks.setdefault(game_id, {}).get(color)
+                if existing:
+                    existing.cancel()
+                self.release_tasks[game_id][color] = asyncio.create_task(
+                    self._release_seat(game_id, color)
+                )
+
+    async def _release_seat(self, game_id: str, color: str) -> None:
+        try:
+            await asyncio.sleep(60)
+            players = self.active.get(game_id)
+            if players and players[color] is None:
+                # Seat becomes available to anyone
+                self.names[game_id][color] = ""
+        finally:
+            # Clear reference to the completed task
+            if game_id in self.release_tasks:
+                self.release_tasks[game_id][color] = None
 
     async def broadcast(self, game_id: str, message: dict) -> None:
         for connection in self.active.get(game_id, {}).values():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,53 @@
+import asyncio
+import pytest
+from fastapi import WebSocketDisconnect
+
+from backend.server import ConnectionManager
+
+
+class DummyWebSocket:
+    async def accept(self):
+        pass
+
+    async def close(self):
+        pass
+
+
+def test_seat_reserved_and_released(monkeypatch):
+    async def run_test():
+        manager = ConnectionManager()
+        gid = manager.create_game()
+
+        # Replace _release_seat with controllable version
+        release_event = asyncio.Event()
+
+        async def fake_release(game_id, color):
+            await release_event.wait()
+            players = manager.active.get(game_id)
+            if players and players[color] is None:
+                manager.names[game_id][color] = ""
+            manager.release_tasks[game_id][color] = None
+
+        monkeypatch.setattr(manager, "_release_seat", fake_release)
+
+        ws1 = DummyWebSocket()
+        color = await manager.connect(gid, ws1, name="alice")
+        manager.names[gid][color] = "alice"
+        manager.disconnect(gid, ws1)
+
+        # Another player connects while seat is reserved.
+        ws2 = DummyWebSocket()
+        color_bob = await manager.connect(gid, ws2, name="bob")
+        assert color_bob != color
+        # Reserved seat is still empty and retains original name.
+        assert manager.active[gid][color] is None
+        assert manager.names[gid][color] == "alice"
+
+        # After releasing the seat, a new player may take it
+        release_event.set()
+        await asyncio.sleep(0)
+        ws3 = DummyWebSocket()
+        color2 = await manager.connect(gid, ws3, name="carol")
+        assert color2 == color
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- Reserve a disconnected player's seat for one minute before allowing others to join
- After the timer expires, free the seat for new players
- Add tests covering seat reservation and release behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68903061df708327ae418a0e03df679e