### PR TITLE
Make white player move first

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Multiplayer browser-based Othello game with a Python backend and WebSocket communication.
 
+**Note:** In this version of the game, the white player moves first.
+
 ## Setup
 
 ```bash

--- a/backend/game.py
+++ b/backend/game.py
@@ -18,7 +18,7 @@ class Game:
         self.board[mid][mid] = -1
         self.board[mid - 1][mid] = 1
         self.board[mid][mid - 1] = 1
-        self.current_player = 1  # black starts
+        self.current_player = -1  # white starts
 
     def inside(self, x: int, y: int) -> bool:
         return 0 <= x < BOARD_SIZE and 0 <= y < BOARD_SIZE

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -11,16 +11,16 @@ from backend.game import Game
 
 def test_initial_valid_moves():
     game = Game()
-    moves = set(game.valid_moves(1))
-    expected = {(2, 3), (3, 2), (4, 5), (5, 4)}
+    moves = set(game.valid_moves(-1))
+    expected = {(2, 4), (3, 5), (4, 2), (5, 3)}
     assert moves == expected
 
 
 def test_move_flips_opponent():
     game = Game()
-    assert game.make_move(2, 3, 1)
-    # The move at (2,3) should flip one white at (3,3)
-    assert game.board[2][3] == 1
-    assert game.board[3][3] == 1
+    assert game.make_move(2, 4, -1)
+    # The move at (2,4) should flip one black at (3,4)
+    assert game.board[2][4] == -1
+    assert game.board[3][4] == -1
     black, white = game.score()
-    assert black == 4 and white == 1
+    assert black == 1 and white == 4


### PR DESCRIPTION
## Summary
- Start game with white's turn instead of black.
- Adjust unit tests to expect white's opening moves and scoring.
- Document that white now moves first.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68903f223b6883279ab8df2e5d002f29