### PR TITLE
Display white player on left and black on right in game room

### DIFF
--- a/static/game.html
+++ b/static/game.html
@@ -8,8 +8,8 @@
 <body>
     <h1>Othello Online</h1>
     <div id="players">
-        <div id="black-player" class="player">Black (<span id="black-count">0</span>): <span id="black-name"></span></div>
         <div id="white-player" class="player">White (<span id="white-count">0</span>): <span id="white-name"></span></div>
+        <div id="black-player" class="player">Black (<span id="black-count">0</span>): <span id="black-name"></span></div>
     </div>
     <div id="board"></div>
     <div id="message"></div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -7,7 +7,10 @@ body {
 }
 
 #players {
-    margin-top: 10px;
+    width: 400px;
+    margin: 10px auto;
+    display: flex;
+    justify-content: space-between;
 }
 
 .player {


### PR DESCRIPTION
## Summary
- Swap player display order so white appears left and black right in game room
- Align player panel using flex to keep white and black at opposite ends

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689093465d9c832793a5cf3db17dc639