### PR TITLE
Add Othello bot opponent and invite feature

### DIFF
--- a/backend/game.py
+++ b/backend/game.py
@@ -78,3 +78,18 @@ class Game:
         white = sum(cell == -1 for row in self.board for cell in row)
         return black, white
 
+    def best_move(self, player: Optional[int] = None) -> Optional[Tuple[int, int]]:
+        """Return the move that captures the most discs for ``player``.
+
+        If no moves are available, ``None`` is returned. A very small
+        heuristic is used: simply choose the move that flips the maximum
+        number of opponent discs. When several moves tie, the first one in
+        scan order is selected.
+        """
+        if player is None:
+            player = self.current_player
+        moves = self.valid_moves(player)
+        if not moves:
+            return None
+        return max(moves, key=lambda m: len(self._captures(m[0], m[1], player)))
+

--- a/static/script.js
+++ b/static/script.js
@@ -144,6 +144,13 @@ function renderPlayers(players, current) {
                 socket.send(JSON.stringify({action: 'sit', color: color, name: playerName}));
             };
             el.appendChild(btn);
+        } else if (playerColor !== color) {
+            const btn = document.createElement('button');
+            btn.textContent = 'Invite Bot';
+            btn.onclick = () => {
+                socket.send(JSON.stringify({action: 'bot', color: color}));
+            };
+            el.appendChild(btn);
         } else {
             el.textContent = 'Waiting...';
         }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -167,3 +167,29 @@ def test_room_removed_when_empty(monkeypatch):
         assert gid not in manager.games
 
     asyncio.run(run_test())
+
+
+def test_bot_moves(monkeypatch):
+    async def run_test():
+        manager = ConnectionManager()
+        gid = manager.create_game()
+
+        # Capture broadcast messages
+        messages = []
+
+        async def fake_broadcast(game_id, message):
+            messages.append(message)
+
+        monkeypatch.setattr(manager, "broadcast", fake_broadcast)
+
+        # Seat a bot as white and let it move (white starts)
+        assert manager.add_bot(gid, "white")
+        await manager.bot_move(gid)
+
+        game = manager.games[gid]
+        # Bot should play a valid move and switch to black's turn
+        assert game.board[2][4] == -1
+        assert game.current_player == 1
+        assert messages and messages[0]["type"] == "update"
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- add `best_move` helper for basic strategy
- support seating bots and auto-playing turns on the server
- allow seated players to invite a bot opponent via UI
- test that a seated bot makes a valid move

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891c1fef2788327aa4ed0dbaf28744b