### PR TITLE
Add ability to restart game

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -109,12 +109,20 @@ function renderBoard(board, current) {
     document.getElementById('white-count').textContent = whiteCount;
     const messageDiv = document.getElementById('message');
     if (current === 0) {
+        let msg;
         if (blackCount > whiteCount) {
-            messageDiv.textContent = 'Game over! Black wins.';
+            msg = 'Game over! Black wins.';
         } else if (whiteCount > blackCount) {
-            messageDiv.textContent = 'Game over! White wins.';
+            msg = 'Game over! White wins.';
         } else {
-            messageDiv.textContent = "Game over! It's a draw.";
+            msg = "Game over! It's a draw.";
+        }
+        messageDiv.textContent = msg + ' ';
+        if (playerColor) {
+            const btn = document.createElement('button');
+            btn.textContent = 'Restart';
+            btn.onclick = sendRestart;
+            messageDiv.appendChild(btn);
         }
     } else {
         messageDiv.textContent = '';
@@ -210,6 +218,12 @@ function captures(board, x, y, player) {
 function sendMove(x, y) {
     if (socket && playerColor) {
         socket.send(JSON.stringify({action: 'move', x: x, y: y, color: playerColor}));
+    }
+}
+
+function sendRestart() {
+    if (socket && playerColor) {
+        socket.send(JSON.stringify({action: 'restart'}));
     }
 }
 


### PR DESCRIPTION
## Summary
- Allow resetting a finished game with a new `restart` websocket action
- Show a restart button to players at game end
- Cover restart logic with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891c4edb78883279aae6ed3e75481d3