### PR TITLE
Add support for multiple Othello bot strategies

### DIFF
--- a/backend/bots.py
+++ b/backend/bots.py
@@ -1,0 +1,38 @@
+"""Bot strategies for Othello."""
+from __future__ import annotations
+
+from typing import Callable, Optional, Tuple
+import copy
+
+from .game import Game
+
+BotStrategy = Callable[[Game, int], Optional[Tuple[int, int]]]
+
+
+def david(game: Game, player: int) -> Optional[Tuple[int, int]]:
+    """David: choose the move that flips the most discs."""
+    return game.best_move(player)
+
+
+def roger(game: Game, player: int) -> Optional[Tuple[int, int]]:
+    """Roger: choose move giving opponent the fewest options next turn."""
+    moves = game.valid_moves(player)
+    if not moves:
+        return None
+    best_move = moves[0]
+    min_opponent = float("inf")
+    for x, y in moves:
+        sim = copy.deepcopy(game)
+        sim.make_move(x, y, player)
+        opp_moves = len(sim.valid_moves(-player))
+        if opp_moves < min_opponent:
+            min_opponent = opp_moves
+            best_move = (x, y)
+    return best_move
+
+
+BOTS: dict[str, BotStrategy] = {
+    "David": david,
+    "Roger": roger,
+}
+

--- a/static/script.js
+++ b/static/script.js
@@ -11,6 +11,7 @@ let currentTurn = 0;
 let currentPlayers = null;
 let currentRatings = null;
 const gameId = window.location.pathname.split('/').pop();
+let availableBots = [];
 
 function connect() {
     if (!gameId) {
@@ -33,6 +34,7 @@ function connect() {
             currentTurn = msg.current;
             currentPlayers = msg.players;
             currentRatings = msg.ratings;
+            availableBots = msg.bots || [];
             renderBoard(currentBoard, currentTurn);
             renderPlayers(currentPlayers, currentTurn);
             if (playerName && playerColor) {
@@ -153,12 +155,23 @@ function renderPlayers(players, current) {
             };
             el.appendChild(btn);
         } else if (playerColor !== color) {
-            const btn = document.createElement('button');
-            btn.textContent = 'Invite Bot';
-            btn.onclick = () => {
-                socket.send(JSON.stringify({action: 'bot', color: color}));
-            };
-            el.appendChild(btn);
+            if (availableBots.length > 0) {
+                const select = document.createElement('select');
+                availableBots.forEach((b) => {
+                    const opt = document.createElement('option');
+                    opt.value = b;
+                    opt.textContent = b;
+                    select.appendChild(opt);
+                });
+                const btn = document.createElement('button');
+                btn.textContent = 'Invite Bot';
+                btn.onclick = () => {
+                    const bot = select.value;
+                    socket.send(JSON.stringify({action: 'bot', color: color, bot: bot}));
+                };
+                el.appendChild(select);
+                el.appendChild(btn);
+            }
         } else {
             el.textContent = 'Waiting...';
         }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -183,15 +183,49 @@ def test_bot_moves(monkeypatch):
 
         monkeypatch.setattr(manager, "broadcast", fake_broadcast)
 
-        # Seat a bot as white and let it move (white starts)
-        assert manager.add_bot(gid, "white")
+        # Seat David as white and let it move (white starts)
+        assert manager.add_bot(gid, "white", "David")
         await manager.bot_move(gid)
 
         game = manager.games[gid]
-        # Bot should play a valid move and switch to black's turn
+        # David should play a valid move and switch to black's turn
         assert game.board[2][4] == -1
         assert game.current_player == 1
         assert messages and messages[0]["type"] == "update"
+
+    asyncio.run(run_test())
+
+
+def test_roger_bot_strategy(monkeypatch):
+    async def run_test():
+        manager = ConnectionManager()
+        gid = manager.create_game()
+
+        # Use a board state where Roger differs from David
+        game = manager.games[gid]
+        game.board = [
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, -1, 1, 0, 0, 0, 0],
+            [0, 0, 1, 1, 1, 1, 0, 0],
+            [0, 0, 1, 1, -1, -1, 0, 0],
+            [0, 0, 1, 1, -1, 0, 0, 0],
+            [0, 0, 1, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+        ]
+        game.current_player = -1
+
+        async def fake_broadcast(game_id, message):
+            pass
+
+        monkeypatch.setattr(manager, "broadcast", fake_broadcast)
+
+        assert manager.add_bot(gid, "white", "Roger")
+        await manager.bot_move(gid)
+
+        # Roger should choose (0,2) in this position
+        assert game.board[0][2] == -1
+        assert game.current_player == 1
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary
- Introduce a dedicated bots module with two strategies: `David` (max captures) and `Roger` (minimize opponent moves).
- Update server to manage named bots, delegate moves via strategy functions, and report available bots to clients.
- Enhance client UI with a bot-selection dropdown to invite specific bots.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891d63321a48327b036f2970eea1d58