### PR TITLE
Add Minnie minimax bot

### DIFF
--- a/backend/bots.py
+++ b/backend/bots.py
@@ -31,8 +31,69 @@ def roger(game: Game, player: int) -> Optional[Tuple[int, int]]:
     return best_move
 
 
+def minnie(game: Game, player: int, depth: int = 3) -> Optional[Tuple[int, int]]:
+    """Minnie: minimax search using a positional weighting heuristic."""
+    WEIGHTS = [
+        [100, -20, 10, 5, 5, 10, -20, 100],
+        [-20, -50, -2, -2, -2, -2, -50, -20],
+        [10, -2, -1, -1, -1, -1, -2, 10],
+        [5, -2, -1, -1, -1, -1, -2, 5],
+        [5, -2, -1, -1, -1, -1, -2, 5],
+        [10, -2, -1, -1, -1, -1, -2, 10],
+        [-20, -50, -2, -2, -2, -2, -50, -20],
+        [100, -20, 10, 5, 5, 10, -20, 100],
+    ]
+
+    def evaluate(g: Game) -> int:
+        """Return weighted score from ``player``'s perspective."""
+        score = 0
+        for x in range(8):
+            for y in range(8):
+                score += WEIGHTS[x][y] * g.board[x][y]
+        return score * player
+
+    def minimax(g: Game, turn: int, d: int) -> int:
+        moves = g.valid_moves(turn)
+        if d == 0:
+            return evaluate(g)
+        if not moves:
+            # Pass turn if opponent has moves; otherwise evaluate
+            if g.valid_moves(-turn):
+                return minimax(g, -turn, d - 1)
+            return evaluate(g)
+        if turn == player:
+            best = -float("inf")
+            for mx, my in moves:
+                sim = copy.deepcopy(g)
+                sim.make_move(mx, my, turn)
+                best = max(best, minimax(sim, -turn, d - 1))
+            return best
+        else:
+            best = float("inf")
+            for mx, my in moves:
+                sim = copy.deepcopy(g)
+                sim.make_move(mx, my, turn)
+                best = min(best, minimax(sim, -turn, d - 1))
+            return best
+
+    moves = game.valid_moves(player)
+    if not moves:
+        return None
+    best_move = moves[0]
+    best_val = -float("inf")
+    for x, y in moves:
+        sim = copy.deepcopy(game)
+        sim.make_move(x, y, player)
+        val = minimax(sim, -player, depth - 1)
+        if val > best_val:
+            best_val = val
+            best_move = (x, y)
+    return best_move
+
+
 BOTS: dict[str, BotStrategy] = {
     "David": david,
     "Roger": roger,
+    "Minnie": minnie,
 }
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -230,6 +230,40 @@ def test_roger_bot_strategy(monkeypatch):
     asyncio.run(run_test())
 
 
+def test_minnie_bot_strategy(monkeypatch):
+    async def run_test():
+        manager = ConnectionManager()
+        gid = manager.create_game()
+
+        # Board state where Minnie chooses (2,4)
+        game = manager.games[gid]
+        game.board = [
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 0, 0, 0, 0, 0, 0],
+            [0, 0, -1, 0, 0, 0, 0, 0],
+            [0, 0, 0, -1, 1, 0, 0, 0],
+            [0, 0, 0, 1, -1, 0, 0, 0],
+            [0, 0, 0, 1, 1, -1, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+        ]
+        game.current_player = -1
+
+        async def fake_broadcast(game_id, message):
+            pass
+
+        monkeypatch.setattr(manager, "broadcast", fake_broadcast)
+
+        assert manager.add_bot(gid, "white", "Minnie")
+        await manager.bot_move(gid)
+
+        # Minnie should choose (2,4) in this position
+        assert game.board[2][4] == -1
+        assert game.current_player == 1
+
+    asyncio.run(run_test())
+
+
 def test_restart_game_resets_board(monkeypatch):
     monkeypatch.setattr(
         ConnectionManager, "_schedule_room_cleanup", lambda self, gid: None


### PR DESCRIPTION
## Summary
- implement Minnie bot with minimax search and positional weights
- expose Minnie in server bot list
- test Minnie behaviour with a custom board state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891da8f5f508327959837a6bd1848b8