### PR TITLE
Display bot selection popup

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -131,6 +131,41 @@ function renderBoard(board, current) {
     }
 }
 
+function showBotPopup(color) {
+    const existing = document.getElementById('bot-popup');
+    if (existing) existing.remove();
+
+    const overlay = document.createElement('div');
+    overlay.id = 'bot-popup';
+    overlay.className = 'popup-overlay';
+    overlay.onclick = (e) => {
+        if (e.target === overlay) overlay.remove();
+    };
+
+    const box = document.createElement('div');
+    box.className = 'popup-box';
+
+    availableBots.forEach((b) => {
+        const item = document.createElement('div');
+        item.className = 'popup-item';
+        item.textContent = b;
+        item.onclick = () => {
+            socket.send(JSON.stringify({action: 'bot', color: color, bot: b}));
+            overlay.remove();
+        };
+        box.appendChild(item);
+    });
+
+    const cancel = document.createElement('div');
+    cancel.className = 'popup-item cancel';
+    cancel.textContent = 'Cancel';
+    cancel.onclick = () => overlay.remove();
+    box.appendChild(cancel);
+
+    overlay.appendChild(box);
+    document.body.appendChild(overlay);
+}
+
 function renderPlayers(players, current) {
     const blackPlayer = document.getElementById('black-player');
     const whitePlayer = document.getElementById('white-player');
@@ -158,34 +193,7 @@ function renderPlayers(players, current) {
             if (availableBots.length > 0) {
                 const btn = document.createElement('button');
                 btn.textContent = 'Invite Bot';
-                btn.onclick = () => {
-                    const existing = el.querySelector('select');
-                    if (existing) existing.remove();
-
-                    const select = document.createElement('select');
-
-                    const placeholder = document.createElement('option');
-                    placeholder.textContent = 'Select a bot';
-                    placeholder.disabled = true;
-                    placeholder.selected = true;
-                    select.appendChild(placeholder);
-
-                    availableBots.forEach((b) => {
-                        const opt = document.createElement('option');
-                        opt.value = b;
-                        opt.textContent = b;
-                        select.appendChild(opt);
-                    });
-
-                    select.onchange = () => {
-                        const bot = select.value;
-                        socket.send(JSON.stringify({action: 'bot', color: color, bot: bot}));
-                        select.remove();
-                    };
-
-                    el.appendChild(select);
-                    select.focus();
-                };
+                btn.onclick = () => showBotPopup(color);
                 el.appendChild(btn);
             }
         } else {

--- a/static/styles.css
+++ b/static/styles.css
@@ -124,3 +124,49 @@ body {
 #create-room:hover {
     background-color: #805a2c;
 }
+
+/* Popup styling for bot selection */
+.popup-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.popup-box {
+    background-color: #0a3d2e;
+    box-shadow: 0 0 10px #000 inset;
+    border: 8px solid #654321;
+    padding: 10px;
+    display: grid;
+    gap: 4px;
+}
+
+.popup-item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgba(0,0,0,0.3);
+    padding: 10px;
+    cursor: pointer;
+}
+
+.popup-item:hover {
+    background-color: rgba(255,255,255,0.2);
+}
+
+.popup-item.cancel {
+    background-color: #654321;
+    color: #fff;
+    border: none;
+}
+
+.popup-item.cancel:hover {
+    background-color: #805a2c;
+}


### PR DESCRIPTION
## Summary
- Show bots in a themed popup when inviting a bot to a game
- Style popup overlay and items to match existing game aesthetic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891e014648c832799944784e75dafeb