### PR TITLE
Show bot list in popup when inviting bots

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -158,34 +158,7 @@ function renderPlayers(players, current) {
             if (availableBots.length > 0) {
                 const btn = document.createElement('button');
                 btn.textContent = 'Invite Bot';
-                btn.onclick = () => {
-                    const existing = el.querySelector('select');
-                    if (existing) existing.remove();
-
-                    const select = document.createElement('select');
-
-                    const placeholder = document.createElement('option');
-                    placeholder.textContent = 'Select a bot';
-                    placeholder.disabled = true;
-                    placeholder.selected = true;
-                    select.appendChild(placeholder);
-
-                    availableBots.forEach((b) => {
-                        const opt = document.createElement('option');
-                        opt.value = b;
-                        opt.textContent = b;
-                        select.appendChild(opt);
-                    });
-
-                    select.onchange = () => {
-                        const bot = select.value;
-                        socket.send(JSON.stringify({action: 'bot', color: color, bot: bot}));
-                        select.remove();
-                    };
-
-                    el.appendChild(select);
-                    select.focus();
-                };
+                btn.onclick = () => showBotPopup(color);
                 el.appendChild(btn);
             }
         } else {
@@ -206,6 +179,34 @@ function renderPlayers(players, current) {
 
     blackPlayer.classList.toggle('you', playerColor === 'black');
     whitePlayer.classList.toggle('you', playerColor === 'white');
+}
+
+function showBotPopup(color) {
+    const overlay = document.createElement('div');
+    overlay.className = 'popup-overlay';
+
+    const popup = document.createElement('div');
+    popup.className = 'popup';
+
+    availableBots.forEach((b) => {
+        const opt = document.createElement('div');
+        opt.className = 'bot-option';
+        opt.textContent = b;
+        opt.onclick = () => {
+            socket.send(JSON.stringify({action: 'bot', color: color, bot: b}));
+            overlay.remove();
+        };
+        popup.appendChild(opt);
+    });
+
+    const cancel = document.createElement('div');
+    cancel.className = 'bot-option';
+    cancel.textContent = 'Cancel';
+    cancel.onclick = () => overlay.remove();
+    popup.appendChild(cancel);
+
+    overlay.appendChild(popup);
+    document.body.appendChild(overlay);
 }
 
 function validMoves(board, player) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -124,3 +124,33 @@ body {
 #create-room:hover {
     background-color: #805a2c;
 }
+
+.popup-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.popup {
+    background-color: #0a3d2e;
+    box-shadow: 0 0 10px #000 inset;
+    border: 8px solid #654321;
+    padding: 10px;
+}
+
+.popup .bot-option {
+    padding: 10px;
+    border: 1px solid rgba(0,0,0,0.3);
+    cursor: pointer;
+    margin: 4px 0;
+}
+
+.popup .bot-option:hover {
+    background-color: rgba(255,255,255,0.2);
+}


### PR DESCRIPTION
## Summary
- Replace dropdown selector with in-game styled popup listing bots
- Add popup styles matching existing board aesthetics

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891e014648c832799944784e75dafeb