### PR TITLE
feat: add bot selection popup

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -159,32 +159,7 @@ function renderPlayers(players, current) {
                 const btn = document.createElement('button');
                 btn.textContent = 'Invite Bot';
                 btn.onclick = () => {
-                    const existing = el.querySelector('select');
-                    if (existing) existing.remove();
-
-                    const select = document.createElement('select');
-
-                    const placeholder = document.createElement('option');
-                    placeholder.textContent = 'Select a bot';
-                    placeholder.disabled = true;
-                    placeholder.selected = true;
-                    select.appendChild(placeholder);
-
-                    availableBots.forEach((b) => {
-                        const opt = document.createElement('option');
-                        opt.value = b;
-                        opt.textContent = b;
-                        select.appendChild(opt);
-                    });
-
-                    select.onchange = () => {
-                        const bot = select.value;
-                        socket.send(JSON.stringify({action: 'bot', color: color, bot: bot}));
-                        select.remove();
-                    };
-
-                    el.appendChild(select);
-                    select.focus();
+                    openBotPopup(color);
                 };
                 el.appendChild(btn);
             }
@@ -206,6 +181,42 @@ function renderPlayers(players, current) {
 
     blackPlayer.classList.toggle('you', playerColor === 'black');
     whitePlayer.classList.toggle('you', playerColor === 'white');
+}
+
+function openBotPopup(color) {
+    const existing = document.getElementById('bot-overlay');
+    if (existing) existing.remove();
+
+    const overlay = document.createElement('div');
+    overlay.id = 'bot-overlay';
+    overlay.className = 'overlay';
+
+    const popup = document.createElement('div');
+    popup.className = 'popup';
+
+    const title = document.createElement('h2');
+    title.textContent = 'Select a Bot';
+    popup.appendChild(title);
+
+    availableBots.forEach((b) => {
+        const opt = document.createElement('div');
+        opt.className = 'bot-option';
+        opt.textContent = b;
+        opt.onclick = () => {
+            socket.send(JSON.stringify({action: 'bot', color: color, bot: b}));
+            overlay.remove();
+        };
+        popup.appendChild(opt);
+    });
+
+    overlay.onclick = (e) => {
+        if (e.target === overlay) {
+            overlay.remove();
+        }
+    };
+
+    overlay.appendChild(popup);
+    document.body.appendChild(overlay);
 }
 
 function validMoves(board, player) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -124,3 +124,37 @@ body {
 #create-room:hover {
     background-color: #805a2c;
 }
+
+/* Bot selection popup */
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.popup {
+    background-color: #0a3d2e;
+    padding: 20px;
+    border: 8px solid #654321;
+    box-shadow: 0 0 10px #000 inset;
+    text-align: center;
+}
+
+.popup .bot-option {
+    margin: 5px 0;
+    padding: 10px;
+    background-color: rgba(0,0,0,0.2);
+    border: 1px solid rgba(0,0,0,0.3);
+    cursor: pointer;
+}
+
+.popup .bot-option:hover {
+    background-color: rgba(255,255,255,0.2);
+}


### PR DESCRIPTION
## Summary
- show popup of bots on "Invite Bot" instead of inline select
- style popup to match existing game theme

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891e014648c832799944784e75dafeb