### PR TITLE
Highlight last move in Othello board

### DIFF
--- a/backend/game.py
+++ b/backend/game.py
@@ -19,6 +19,9 @@ class Game:
         self.board[mid - 1][mid] = 1
         self.board[mid][mid - 1] = 1
         self.current_player = -1  # white starts
+        # Track the coordinates of the most recent move. ``None`` means no
+        # moves have been played yet.
+        self.last_move: Optional[Tuple[int, int]] = None
 
     def inside(self, x: int, y: int) -> bool:
         return 0 <= x < BOARD_SIZE and 0 <= y < BOARD_SIZE
@@ -63,6 +66,10 @@ class Game:
         if not captured:
             return False
         self.board[x][y] = player
+        # Record the move before flipping captured discs. This information is
+        # surfaced to clients so they can highlight the last move played on the
+        # board.
+        self.last_move = (x, y)
         for cx, cy in captured:
             self.board[cx][cy] = player
         self.current_player = -player

--- a/backend/server.py
+++ b/backend/server.py
@@ -288,6 +288,7 @@ class ConnectionManager:
                 {
                     "type": "update",
                     "board": game.board,
+                    "last": game.last_move,
                     "current": game.current_player,
                     "players": self.names[game_id],
                     "ratings": self.get_game_ratings(game_id),
@@ -399,6 +400,7 @@ async def websocket_endpoint(websocket: WebSocket, game_id: str):
             {
                 "type": "init",
                 "board": game.board,
+                "last": game.last_move,
                 "color": color,
                 "current": game.current_player,
                 "players": manager.names[game_id],
@@ -423,6 +425,7 @@ async def websocket_endpoint(websocket: WebSocket, game_id: str):
                         {
                             "type": "update",
                             "board": game.board,
+                            "last": game.last_move,
                             "current": game.current_player,
                             "players": manager.names[game_id],
                             "ratings": manager.get_game_ratings(game_id),
@@ -492,6 +495,7 @@ async def websocket_endpoint(websocket: WebSocket, game_id: str):
                         {
                             "type": "update",
                             "board": game.board,
+                            "last": game.last_move,
                             "current": game.current_player,
                             "players": manager.names[game_id],
                             "ratings": manager.get_game_ratings(game_id),

--- a/static/script.js
+++ b/static/script.js
@@ -12,6 +12,8 @@ let currentPlayers = null;
 let currentRatings = null;
 const gameId = window.location.pathname.split('/').pop();
 let availableBots = [];
+// Track the last move sent by the server so we can highlight it.
+let lastMove = null;
 
 function connect() {
     if (!gameId) {
@@ -34,8 +36,9 @@ function connect() {
             currentTurn = msg.current;
             currentPlayers = msg.players;
             currentRatings = msg.ratings;
+            lastMove = msg.last;
             availableBots = msg.bots || [];
-            renderBoard(currentBoard, currentTurn);
+            renderBoard(currentBoard, currentTurn, lastMove);
             renderPlayers(currentPlayers, currentTurn);
             if (playerName && playerColor) {
                 socket.send(JSON.stringify({action: 'name', name: playerName}));
@@ -45,7 +48,8 @@ function connect() {
             currentTurn = msg.current;
             currentPlayers = msg.players;
             currentRatings = msg.ratings;
-            renderBoard(currentBoard, currentTurn);
+            lastMove = msg.last;
+            renderBoard(currentBoard, currentTurn, lastMove);
             renderPlayers(currentPlayers, currentTurn);
         } else if (msg.type === 'players') {
             currentPlayers = msg.players;
@@ -60,7 +64,7 @@ function connect() {
             // Re-render the board and player list so the newly seated player
             // can immediately interact with the game without refreshing.
             if (currentBoard) {
-                renderBoard(currentBoard, currentTurn);
+                renderBoard(currentBoard, currentTurn, lastMove);
             }
             if (currentPlayers) {
                 renderPlayers(currentPlayers, currentTurn);
@@ -71,7 +75,7 @@ function connect() {
     };
 }
 
-function renderBoard(board, current) {
+function renderBoard(board, current, last) {
     const boardDiv = document.getElementById('board');
     boardDiv.innerHTML = '';
     const turnColor = current === 1 ? 'black' : current === -1 ? 'white' : null;
@@ -97,6 +101,9 @@ function renderBoard(board, current) {
             if (cell !== 0) {
                 const disc = document.createElement('div');
                 disc.className = 'disc ' + (cell === 1 ? 'black' : 'white');
+                if (last && last[0] === x && last[1] === y) {
+                    disc.classList.add('last');
+                }
                 cellDiv.appendChild(disc);
                 if (cell === 1) {
                     blackCount++;

--- a/static/styles.css
+++ b/static/styles.css
@@ -85,6 +85,19 @@ body {
     background: radial-gradient(circle at 30% 30%, #fff, #ccc);
 }
 
+/* Mark the most recent move with a small red dot. */
+.disc.last::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 20%;
+    height: 20%;
+    background: red;
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+}
+
 /* Lobby styling */
 #rooms {
     margin: 20px auto;

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -24,3 +24,10 @@ def test_move_flips_opponent():
     assert game.board[3][4] == -1
     black, white = game.score()
     assert black == 1 and white == 4
+
+
+def test_last_move_tracking():
+    game = Game()
+    assert game.last_move is None
+    assert game.make_move(2, 4, -1)
+    assert game.last_move == (2, 4)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -192,6 +192,8 @@ def test_bot_moves(monkeypatch):
         assert game.board[2][4] == -1
         assert game.current_player == 1
         assert messages and messages[0]["type"] == "update"
+        # Broadcast message should include the last move location
+        assert messages[0]["last"] == (2, 4)
 
     asyncio.run(run_test())
 
@@ -273,7 +275,9 @@ def test_restart_game_resets_board(monkeypatch):
     game = manager.games[gid]
     game.board[0][0] = 1
     game.current_player = 0
+    game.last_move = (0, 0)
     assert manager.restart_game(gid)
     new_game = manager.games[gid]
     assert new_game.current_player == -1
     assert new_game.board == Game().board
+    assert new_game.last_move is None


### PR DESCRIPTION
## Summary
- Track last move within the game state and expose it to clients.
- Broadcast last move data and highlight it in the UI with a red dot.
- Add tests for last move tracking, broadcasting, and restart handling.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891e72fb570832786b9e73265679e93