### PR TITLE
Tweak last move indicator styling

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -91,9 +91,9 @@ body {
     position: absolute;
     top: 50%;
     left: 50%;
-    width: 20%;
-    height: 20%;
-    background: red;
+    width: 16%;
+    height: 16%;
+    background: #cc0000;
     border-radius: 50%;
     transform: translate(-50%, -50%);
 }


### PR DESCRIPTION
## Summary
- Reduce last move marker dot size to be slimmer
- Use a subtler red shade for the marker

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891edfabf6c83279d41aa3da37ca86d