### PR TITLE
Move chat frame beside board

### DIFF
--- a/static/game.html
+++ b/static/game.html
@@ -11,14 +11,18 @@
         <div id="white-player" class="player">White (<span id="white-count">0</span>): <span id="white-name"></span> <span class="rating" id="white-rating"></span></div>
         <div id="black-player" class="player">Black (<span id="black-count">0</span>): <span id="black-name"></span> <span class="rating" id="black-rating"></span></div>
     </div>
-    <div id="board"></div>
-    <div id="message"></div>
-    <div id="chat">
-        <div id="chat-log"></div>
-        <form id="chat-form">
-            <input id="chat-input" type="text" autocomplete="off" placeholder="Say something..." />
-            <button type="submit">Send</button>
-        </form>
+    <div id="game-wrapper">
+        <div id="board-container">
+            <div id="board"></div>
+            <div id="message"></div>
+        </div>
+        <div id="chat">
+            <div id="chat-log"></div>
+            <form id="chat-form">
+                <input id="chat-input" type="text" autocomplete="off" placeholder="Say something..." />
+                <button type="submit">Send</button>
+            </form>
+        </div>
     </div>
     <script src="/static/script.js"></script>
 </body>

--- a/static/styles.css
+++ b/static/styles.css
@@ -6,6 +6,19 @@ body {
     text-align: center;
 }
 
+#game-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 20px;
+}
+
+#board-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
 #players {
     width: 400px;
     margin: 10px auto;
@@ -41,7 +54,7 @@ body {
 }
 
 #board {
-    margin: 20px auto;
+    margin: 20px 0;
     width: 400px;
     height: 400px;
     display: grid;
@@ -54,8 +67,10 @@ body {
 
 #chat {
     width: 400px;
-    margin: 20px auto;
+    margin: 20px 0;
     text-align: left;
+    border: 8px solid #654321;
+    box-shadow: 0 0 10px #000 inset;
 }
 
 #chat-log {


### PR DESCRIPTION
## Summary
- Arrange game board and chat side-by-side via new wrapper layout.
- Add thick bordered styling for chat panel.

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68927096145c832786b437f5a557e293