### PR TITLE
Align chat room with game board

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -66,8 +66,8 @@ body {
 }
 
 #chat {
-    position: fixed;
-    top: 0;
+    position: absolute;
+    top: 20px;
     right: 0;
     width: min(400px, max(0px, calc(50vw - 200px)));
     height: 400px;


### PR DESCRIPTION
## Summary
- Position chat absolutely within game wrapper and offset vertically to line up with board

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892de499d14832786afc2b6f929ea6c