### PR TITLE
Center board and reposition player names

### DIFF
--- a/static/game.html
+++ b/static/game.html
@@ -7,13 +7,13 @@
 </head>
 <body>
     <h1>Othello Online</h1>
-    <div id="players">
-        <div id="white-player" class="player">White (<span id="white-count">0</span>): <span id="white-name"></span> <span class="rating" id="white-rating"></span></div>
-        <div id="black-player" class="player">Black (<span id="black-count">0</span>): <span id="black-name"></span> <span class="rating" id="black-rating"></span></div>
-    </div>
     <div id="game-wrapper">
         <div id="board-container">
             <div id="board"></div>
+            <div id="players">
+                <div id="white-player" class="player">White (<span id="white-count">0</span>): <span id="white-name"></span> <span class="rating" id="white-rating"></span></div>
+                <div id="black-player" class="player">Black (<span id="black-count">0</span>): <span id="black-name"></span> <span class="rating" id="black-rating"></span></div>
+            </div>
             <div id="message"></div>
         </div>
         <div id="chat">

--- a/static/styles.css
+++ b/static/styles.css
@@ -10,18 +10,21 @@ body {
 #game-wrapper {
     position: relative;
     width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
 }
 
 #board-container {
+    flex: 1;
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin: 0 auto;
 }
 
 #players {
     width: 400px;
-    margin: 10px auto;
+    margin: 10px auto 0;
     display: flex;
     justify-content: space-between;
 }
@@ -66,9 +69,6 @@ body {
 }
 
 #chat {
-    position: fixed;
-    top: 0px;
-    right: 0;
     width: min(400px, max(0px, calc(30vw - 200px)));
     height: 100vh;
     display: flex;


### PR DESCRIPTION
## Summary
- Center game board in remaining space beside the chat
- Place player name panel beneath the board

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893174741b08327b1691910b2269bc6