### PR TITLE
Center board and reposition player names

### DIFF
--- a/static/game.html
+++ b/static/game.html
@@ -7,13 +7,13 @@
 </head>
 <body>
     <h1>Othello Online</h1>
-    <div id="players">
-        <div id="white-player" class="player">White (<span id="white-count">0</span>): <span id="white-name"></span> <span class="rating" id="white-rating"></span></div>
-        <div id="black-player" class="player">Black (<span id="black-count">0</span>): <span id="black-name"></span> <span class="rating" id="black-rating"></span></div>
-    </div>
     <div id="game-wrapper">
         <div id="board-container">
             <div id="board"></div>
+            <div id="players">
+                <div id="white-player" class="player">White (<span id="white-count">0</span>): <span id="white-name"></span> <span class="rating" id="white-rating"></span></div>
+                <div id="black-player" class="player">Black (<span id="black-count">0</span>): <span id="black-name"></span> <span class="rating" id="black-rating"></span></div>
+            </div>
             <div id="message"></div>
         </div>
         <div id="chat">

--- a/static/styles.css
+++ b/static/styles.css
@@ -10,6 +10,8 @@ body {
 #game-wrapper {
     position: relative;
     width: 100%;
+    padding-right: min(400px, max(0px, calc(30vw - 200px)));
+    box-sizing: border-box;
 }
 
 #board-container {
@@ -21,7 +23,7 @@ body {
 
 #players {
     width: 400px;
-    margin: 10px auto;
+    margin: 10px auto 0;
     display: flex;
     justify-content: space-between;
 }
@@ -67,7 +69,7 @@ body {
 
 #chat {
     position: fixed;
-    top: 0px;
+    top: 0;
     right: 0;
     width: min(400px, max(0px, calc(30vw - 200px)));
     height: 100vh;


### PR DESCRIPTION
## Summary
- Center game board in remaining space beside the chat
- Place player name panel beneath the board
- Anchor chat panel to the top of the page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893174741b08327b1691910b2269bc6