### PR TITLE
Move chatroom to bottom of game screen

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -8,14 +8,14 @@ body {
 }
 
 #game-wrapper {
-    position: relative;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
     width: 100%;
-    padding-right: min(400px, max(0px, calc(30vw - 200px)));
     box-sizing: border-box;
 }
 
 #board-container {
-    flex: 1;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -68,11 +68,8 @@ body {
 }
 
 #chat {
-    position: fixed;
-    top: 0;
-    right: 0;
-    width: min(400px, max(0px, calc(30vw - 200px)));
-    height: 100vh;
+    width: 100%;
+    flex: 1;
     display: flex;
     flex-direction: column;
     text-align: left;


### PR DESCRIPTION
## Summary
- relocate chat panel to bottom of game view
- adjust layout so board sits above chat while retaining existing style

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893234075a48327bddc52e8f81e0566