### PR TITLE
Display player tabs above game board

### DIFF
--- a/static/game.html
+++ b/static/game.html
@@ -8,11 +8,9 @@
 <body>
     <div id="game-wrapper">
         <div id="board-container">
+            <div id="white-player" class="player"><span id="white-name"></span> (<span id="white-count">0</span>)</div>
+            <div id="black-player" class="player"><span id="black-name"></span> (<span id="black-count">0</span>)</div>
             <div id="board"></div>
-            <div id="players">
-                <div id="white-player" class="player">White (<span id="white-count">0</span>): <span id="white-name"></span> <span class="rating" id="white-rating"></span></div>
-                <div id="black-player" class="player">Black (<span id="black-count">0</span>): <span id="black-name"></span> <span class="rating" id="black-rating"></span></div>
-            </div>
             <div id="message"></div>
         </div>
         <div id="chat">

--- a/static/script.js
+++ b/static/script.js
@@ -145,8 +145,6 @@ function renderPlayers(players, current) {
     const whitePlayer = document.getElementById('white-player');
     const blackName = document.getElementById('black-name');
     const whiteName = document.getElementById('white-name');
-    const blackRating = document.getElementById('black-rating');
-    const whiteRating = document.getElementById('white-rating');
 
     // Helper to render a seat
     function renderSeat(color, el, name) {
@@ -179,11 +177,6 @@ function renderPlayers(players, current) {
 
     renderSeat('black', blackName, players.black);
     renderSeat('white', whiteName, players.white);
-
-    if (currentRatings) {
-        blackRating.textContent = players.black ? currentRatings.black ?? '' : '';
-        whiteRating.textContent = players.white ? currentRatings.white ?? '' : '';
-    }
 
     blackPlayer.classList.toggle('active', current === 1);
     whitePlayer.classList.toggle('active', current === -1);

--- a/static/styles.css
+++ b/static/styles.css
@@ -19,26 +19,36 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
-}
-
-#players {
+    position: relative;
     width: 400px;
-    margin: 10px auto 0;
-    display: flex;
-    justify-content: space-between;
+    margin: 0 auto;
+    padding-top: 30px;
 }
 
 .player {
-    display: inline-block;
-    margin: 0 10px;
-    padding: 5px 10px;
-    border-radius: 4px;
-    background-color: rgba(0,0,0,0.2);
+    position: absolute;
+    top: 0;
+    padding: 4px 8px;
+    border-radius: 4px 4px 0 0;
+    font-size: 0.9em;
 }
 
-.rating {
-    margin-left: 4px;
+#white-player {
+    left: 0;
+    background-color: rgba(255,255,255,0.8);
+    color: #000;
+}
+
+#black-player {
+    right: 0;
+    background-color: rgba(0,0,0,0.8);
+    color: #fff;
+}
+
+#white-count,
+#black-count {
     font-weight: bold;
+    margin-left: 4px;
 }
 
 .player.active {
@@ -56,7 +66,7 @@ body {
 }
 
 #board {
-    margin: 20px 0;
+    margin: 0 0 20px;
     width: 400px;
     height: 400px;
     display: grid;


### PR DESCRIPTION
## Summary
- Present white and black player info in slim tabs above the board
- Remove rating display and streamline player rendering logic
## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689333f243488327a7e9e730327c62eb