### PR TITLE
Remove player name border

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -178,9 +178,6 @@ function renderPlayers(players, current) {
     renderSeat('black', blackName, players.black);
     renderSeat('white', whiteName, players.white);
 
-    blackPlayer.classList.toggle('active', current === 1);
-    whitePlayer.classList.toggle('active', current === -1);
-
     blackPlayer.classList.toggle('you', playerColor === 'black');
     whitePlayer.classList.toggle('you', playerColor === 'white');
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -51,10 +51,6 @@ body {
     margin-left: 4px;
 }
 
-.player.active {
-    border: 2px solid #fff;
-}
-
 .player.you {
     background-color: rgba(255, 255, 0, 0.3);
     font-weight: bold;


### PR DESCRIPTION
## Summary
- drop `active` class styling so player names no longer have a border
- stop toggling the unused `active` class in the frontend script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68933676238c8327947f3ec567d0252a