### PR TITLE
Remove gap between player name tabs

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -29,20 +29,24 @@ body {
     position: absolute;
     top: 0;
     padding: 4px 8px;
-    border-radius: 4px 4px 0 0;
+    width: 50%;
+    box-sizing: border-box;
     font-size: 0.9em;
+    text-align: center;
 }
 
 #white-player {
     left: 0;
     background-color: rgba(255,255,255,0.8);
     color: #000;
+    border-radius: 4px 0 0 0;
 }
 
 #black-player {
     right: 0;
     background-color: rgba(0,0,0,0.8);
     color: #fff;
+    border-radius: 0 4px 0 0;
 }
 
 #white-count,


### PR DESCRIPTION
## Summary
- Align player name tabs to occupy half the board each so they meet in the middle
- Adjust tab border radii and layout to eliminate spacing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68933ae251b4832783a54bedc4712707