### PR TITLE
Rearrange player displays beside board

### DIFF
--- a/static/game.html
+++ b/static/game.html
@@ -9,9 +9,19 @@
     <div id="game-wrapper">
 	    <h1>Othello</h1>
         <div id="board-container">
-            <div id="white-player" class="player"><span id="white-name"></span> (<span id="white-count">0</span>)</div>
-            <div id="black-player" class="player"><span id="black-name"></span> (<span id="black-count">0</span>)</div>
-            <div id="board"></div>
+            <div id="board-area">
+                <div id="board"></div>
+                <div id="player-info">
+                    <div id="white-player" class="player-row">
+                        <div class="score-circle white"><span id="white-count">0</span></div>
+                        <span id="white-name"></span> <span id="white-score"></span>
+                    </div>
+                    <div id="black-player" class="player-row">
+                        <div class="score-circle black"><span id="black-count">0</span></div>
+                        <span id="black-name"></span> <span id="black-score"></span>
+                    </div>
+                </div>
+            </div>
             <div id="message"></div>
         </div>
         <div id="chat">

--- a/static/script.js
+++ b/static/script.js
@@ -141,26 +141,32 @@ function renderBoard(board, current, last) {
 }
 
 function renderPlayers(players, current) {
-    const blackPlayer = document.getElementById('black-player');
-    const whitePlayer = document.getElementById('white-player');
     const blackName = document.getElementById('black-name');
     const whiteName = document.getElementById('white-name');
+    const blackScore = document.getElementById('black-score');
+    const whiteScore = document.getElementById('white-score');
 
     // Helper to render a seat
-    function renderSeat(color, el, name) {
-        el.innerHTML = '';
+    function renderSeat(color, nameEl, scoreEl, name) {
+        nameEl.innerHTML = '';
+        scoreEl.textContent = '';
         if (name) {
-            el.textContent = name;
+            let display = name;
             if (playerColor === color) {
-                el.textContent += ' (You)';
+                display += ' (you)';
             }
+            const rating = currentRatings && currentRatings[color];
+            if (rating) {
+                scoreEl.textContent = `(${rating})`;
+            }
+            nameEl.textContent = display;
         } else if (!playerColor) {
             const btn = document.createElement('button');
             btn.textContent = 'Sit';
             btn.onclick = () => {
                 socket.send(JSON.stringify({action: 'sit', color: color, name: playerName}));
             };
-            el.appendChild(btn);
+            nameEl.appendChild(btn);
         } else if (playerColor !== color) {
             if (availableBots.length > 0) {
                 const btn = document.createElement('button');
@@ -168,18 +174,15 @@ function renderPlayers(players, current) {
                 btn.onclick = () => {
                     openBotPopup(color);
                 };
-                el.appendChild(btn);
+                nameEl.appendChild(btn);
             }
         } else {
-            el.textContent = 'Waiting...';
+            nameEl.textContent = 'Waiting...';
         }
     }
 
-    renderSeat('black', blackName, players.black);
-    renderSeat('white', whiteName, players.white);
-
-    blackPlayer.classList.toggle('you', playerColor === 'black');
-    whitePlayer.classList.toggle('you', playerColor === 'white');
+    renderSeat('white', whiteName, whiteScore, players.white);
+    renderSeat('black', blackName, blackScore, players.black);
 }
 
 function openBotPopup(color) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -25,21 +25,33 @@ body {
 }
 
 #board-area {
-    display: flex;
+    position: relative;
+    width: 416px;
+    height: 416px;
+    margin: 0 auto;
 }
 
 #player-info {
+    position: absolute;
+    top: 8px;
+    left: calc(100% + 20px);
     display: grid;
     grid-template-rows: repeat(8, 1fr);
     height: 400px;
-    margin-left: 20px;
-    margin-top: 8px;
     width: 150px;
 }
 
 .player-row {
     display: flex;
     align-items: center;
+    white-space: nowrap;
+}
+
+#white-name,
+#black-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 #white-player {
@@ -62,13 +74,14 @@ body {
 }
 
 .score-circle.black {
-    background: radial-gradient(circle at 30% 30%, #555, #000);
+    background-color: #000;
     color: #fff;
 }
 
 .score-circle.white {
-    background: radial-gradient(circle at 30% 30%, #fff, #ccc);
+    background-color: #fff;
     color: #000;
+    border: 1px solid #000;
 }
 
 #white-count,

--- a/static/styles.css
+++ b/static/styles.css
@@ -20,40 +20,65 @@ body {
     flex-direction: column;
     align-items: center;
     position: relative;
-    width: 400px;
     margin: 0 auto;
     padding-top: 30px;
 }
 
-.player {
-    position: absolute;
-    top: 0;
-    padding: 4px 8px;
-    border-radius: 4px 4px 0 0;
-    font-size: 0.9em;
+#board-area {
+    display: flex;
+}
+
+#player-info {
+    display: grid;
+    grid-template-rows: repeat(8, 1fr);
+    height: 400px;
+    margin-left: 20px;
+    margin-top: 8px;
+    width: 150px;
+}
+
+.player-row {
+    display: flex;
+    align-items: center;
 }
 
 #white-player {
-    left: 0;
-    background-color: rgba(255,255,255,0.8);
-    color: #000;
+    grid-row: 7;
 }
 
 #black-player {
-    right: 0;
-    background-color: rgba(0,0,0,0.8);
+    grid-row: 8;
+}
+
+.score-circle {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    margin-right: 8px;
+}
+
+.score-circle.black {
+    background: radial-gradient(circle at 30% 30%, #555, #000);
     color: #fff;
+}
+
+.score-circle.white {
+    background: radial-gradient(circle at 30% 30%, #fff, #ccc);
+    color: #000;
 }
 
 #white-count,
 #black-count {
     font-weight: bold;
-    margin-left: 4px;
 }
 
-.player.you {
-    background-color: rgba(255, 255, 0, 0.3);
-    font-weight: bold;
+#white-score,
+#black-score {
+    margin-left: 4px;
 }
 
 #message {


### PR DESCRIPTION
## Summary
- Move player info to a sidebar next to the board with colored score circles
- Style scoreboard to align white and black players with corresponding board rows
- Show each player's rating and mark current player with "(you)"

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689470d459188327b9efd59ac76af318