### PR TITLE
feat: show player list beside chat

### DIFF
--- a/static/game.html
+++ b/static/game.html
@@ -23,7 +23,6 @@
                 </form>
             </div>
             <div id="player-list">
-                <h3>Players</h3>
                 <ul id="player-names"></ul>
             </div>
         </div>

--- a/static/game.html
+++ b/static/game.html
@@ -14,12 +14,18 @@
             <div id="board"></div>
             <div id="message"></div>
         </div>
-        <div id="chat">
-            <div id="chat-log"></div>
-            <form id="chat-form">
-                <input id="chat-input" type="text" autocomplete="off" placeholder="Say something..." />
-                <button type="submit">Send</button>
-            </form>
+        <div id="chat-wrapper">
+            <div id="chat">
+                <div id="chat-log"></div>
+                <form id="chat-form">
+                    <input id="chat-input" type="text" autocomplete="off" placeholder="Say something..." />
+                    <button type="submit">Send</button>
+                </form>
+            </div>
+            <div id="player-list">
+                <h3>Players</h3>
+                <ul id="player-names"></ul>
+            </div>
         </div>
     </div>
     <script src="/static/script.js"></script>

--- a/static/script.js
+++ b/static/script.js
@@ -189,14 +189,15 @@ function renderPlayers(players, spectators, current) {
     if (list) {
         list.innerHTML = '';
         const entries = [];
-        if (players.black) entries.push({label: 'Black', name: players.black});
-        if (players.white) entries.push({label: 'White', name: players.white});
+        if (players.black) entries.push({role: 'black', name: players.black});
+        if (players.white) entries.push({role: 'white', name: players.white});
         spectators.forEach((n) => {
-            if (n) entries.push({label: 'Spectator', name: n});
+            if (n) entries.push({role: 'spectator', name: n});
         });
         entries.forEach((e) => {
             const li = document.createElement('li');
-            li.textContent = e.label ? `${e.label}: ${e.name}` : e.name;
+            li.textContent = e.name;
+            li.classList.add(e.role);
             if (e.name === playerName) {
                 li.textContent += ' (You)';
             }

--- a/static/styles.css
+++ b/static/styles.css
@@ -73,9 +73,15 @@ body {
     border: 8px solid #654321;
 }
 
-#chat {
+#chat-wrapper {
     width: 100%;
     flex: 1;
+    display: flex;
+}
+
+#chat {
+    width: 75%;
+    flex: 0 0 75%;
     display: flex;
     flex-direction: column;
     text-align: left;
@@ -83,6 +89,29 @@ body {
     color: #000;
     border: none;
     box-shadow: none;
+}
+
+#player-list {
+    width: 25%;
+    flex: 0 0 25%;
+    background-color: #f0f0f0;
+    color: #000;
+    padding: 5px;
+    overflow-y: auto;
+}
+
+#player-list h3 {
+    margin-top: 0;
+}
+
+#player-list ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+#player-list li {
+    margin-bottom: 4px;
 }
 
 #chat-log {

--- a/static/styles.css
+++ b/static/styles.css
@@ -80,8 +80,8 @@ body {
 }
 
 #chat {
-    width: 75%;
-    flex: 0 0 75%;
+    width: 80%;
+    flex: 0 0 80%;
     display: flex;
     flex-direction: column;
     text-align: left;
@@ -92,16 +92,12 @@ body {
 }
 
 #player-list {
-    width: 25%;
-    flex: 0 0 25%;
-    background-color: #f0f0f0;
-    color: #000;
+    width: 20%;
+    flex: 0 0 20%;
+    background-color: #222;
+    color: #bbb;
     padding: 5px;
     overflow-y: auto;
-}
-
-#player-list h3 {
-    margin-top: 0;
 }
 
 #player-list ul {
@@ -114,11 +110,37 @@ body {
     margin-bottom: 4px;
 }
 
+#player-list li.white {
+    color: #fff;
+}
+
+#player-list li.black {
+    color: #000;
+    background-color: #fff;
+    padding: 0 2px;
+}
+
 #chat-log {
     flex: 1;
     overflow-y: auto;
     background-color: rgba(255, 255, 0, 0.1);
     padding: 5px;
+}
+
+#chat-log,
+#player-list {
+    scrollbar-width: thin;
+}
+
+#chat-log::-webkit-scrollbar,
+#player-list::-webkit-scrollbar {
+    width: 6px;
+}
+
+#chat-log::-webkit-scrollbar-thumb,
+#player-list::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.5);
+    border-radius: 3px;
 }
 
 #chat-form {


### PR DESCRIPTION
## Summary
- track spectator names and broadcast participant lists from the server
- split the chat view to add a player list sidebar

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894711a18448327963011d26c54a28b