### PR TITLE
Add lobby navigation link to game room

### DIFF
--- a/static/game.html
+++ b/static/game.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>
+    <a id="back-to-lobby" href="/">Back to Lobby</a>
     <div id="game-wrapper">
 	    <h1>Othello</h1>
         <div id="board-container">

--- a/static/styles.css
+++ b/static/styles.css
@@ -7,6 +7,21 @@ body {
     margin: 0;
 }
 
+#back-to-lobby {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    color: #fff;
+    text-decoration: none;
+    background-color: #654321;
+    padding: 5px 10px;
+    border-radius: 4px;
+}
+
+#back-to-lobby:hover {
+    background-color: #805a2c;
+}
+
 #game-wrapper {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- add "Back to Lobby" link on the game page
- style link to appear at the top-left corner

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689471359b14832799b78dc27c39127a