### PR TITLE
Fix board update lag before bot moves

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -466,7 +466,8 @@ async def websocket_endpoint(websocket: WebSocket, game_id: str):
                             "ratings": manager.get_game_ratings(game_id),
                         },
                     )
-                    await manager.bot_move(game_id)
+                    # Let the player see their move before the bot responds.
+                    asyncio.create_task(manager.bot_move(game_id))
                 else:
                     await websocket.send_text(json.dumps({"type": "error", "message": "Invalid move"}))
             elif action == "name":
@@ -497,7 +498,8 @@ async def websocket_endpoint(websocket: WebSocket, game_id: str):
                             "ratings": manager.get_game_ratings(game_id),
                         },
                     )
-                    await manager.bot_move(game_id)
+                    # Run bot moves asynchronously so the UI updates immediately.
+                    asyncio.create_task(manager.bot_move(game_id))
                 else:
                     await websocket.send_text(json.dumps({"type": "error", "message": "Seat taken"}))
             elif action == "bot":
@@ -518,7 +520,7 @@ async def websocket_endpoint(websocket: WebSocket, game_id: str):
                             "ratings": manager.get_game_ratings(game_id),
                         },
                     )
-                    await manager.bot_move(game_id)
+                    asyncio.create_task(manager.bot_move(game_id))
                 else:
                     await websocket.send_text(json.dumps({"type": "error", "message": "Seat taken"}))
             elif action == "chat":
@@ -545,7 +547,7 @@ async def websocket_endpoint(websocket: WebSocket, game_id: str):
                             "ratings": manager.get_game_ratings(game_id),
                         },
                     )
-                    await manager.bot_move(game_id)
+                    asyncio.create_task(manager.bot_move(game_id))
                 else:
                     await websocket.send_text(
                         json.dumps({"type": "error", "message": "Cannot restart"})


### PR DESCRIPTION
## Summary
- Run bot moves asynchronously so board updates immediately after a player's move or other actions.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894898b22688327815c7af24e0f790b