### PR TITLE
Allow players to stand up after finished games

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -134,6 +134,11 @@ function renderBoard(board, current, last) {
             btn.textContent = 'Restart';
             btn.onclick = sendRestart;
             messageDiv.appendChild(btn);
+            messageDiv.appendChild(document.createTextNode(' '));
+            const standBtn = document.createElement('button');
+            standBtn.textContent = 'Stand Up';
+            standBtn.onclick = sendStand;
+            messageDiv.appendChild(standBtn);
         }
     } else {
         messageDiv.textContent = '';
@@ -266,6 +271,12 @@ function sendMove(x, y) {
 function sendRestart() {
     if (socket && playerColor) {
         socket.send(JSON.stringify({action: 'restart'}));
+    }
+}
+
+function sendStand() {
+    if (socket && playerColor) {
+        socket.send(JSON.stringify({action: 'stand'}));
     }
 }
 


### PR DESCRIPTION
## Summary
- add "Stand Up" button next to Restart when a game ends
- implement server-side handling to free a player's seat and remove any bot opponent
- test that standing up empties the seat and clears bot opponents

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68948f63227c8327b0e78c972df49474