### PR TITLE
perf: speed up Sasha bot with lightweight game copies

### DIFF
--- a/backend/bots.py
+++ b/backend/bots.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from typing import Callable, Optional, Tuple
-import copy
 
 from .game import Game
 
@@ -22,7 +21,7 @@ def roger(game: Game, player: int) -> Optional[Tuple[int, int]]:
     best_move = moves[0]
     min_opponent = float("inf")
     for x, y in moves:
-        sim = copy.deepcopy(game)
+        sim = game.copy()
         sim.make_move(x, y, player)
         opp_moves = len(sim.valid_moves(-player))
         if opp_moves < min_opponent:
@@ -64,14 +63,14 @@ def minnie(game: Game, player: int, depth: int = 3) -> Optional[Tuple[int, int]]
         if turn == player:
             best = -float("inf")
             for mx, my in moves:
-                sim = copy.deepcopy(g)
+                sim = g.copy()
                 sim.make_move(mx, my, turn)
                 best = max(best, minimax(sim, -turn, d - 1))
             return best
         else:
             best = float("inf")
             for mx, my in moves:
-                sim = copy.deepcopy(g)
+                sim = g.copy()
                 sim.make_move(mx, my, turn)
                 best = min(best, minimax(sim, -turn, d - 1))
             return best
@@ -82,7 +81,7 @@ def minnie(game: Game, player: int, depth: int = 3) -> Optional[Tuple[int, int]]
     best_move = moves[0]
     best_val = -float("inf")
     for x, y in moves:
-        sim = copy.deepcopy(game)
+        sim = game.copy()
         sim.make_move(x, y, player)
         val = minimax(sim, -player, depth - 1)
         if val > best_val:
@@ -199,7 +198,7 @@ def sasha(game: Game, player: int, max_depth: int = 6) -> Optional[Tuple[int, in
         if turn == player:
             value = -float("inf")
             for mx, my in order_moves(g, moves, turn):
-                sim = copy.deepcopy(g)
+                sim = g.copy()
                 sim.make_move(mx, my, turn)
                 value = max(value, alphabeta(sim, depth - 1, alpha, beta, -turn))
                 alpha = max(alpha, value)
@@ -208,7 +207,7 @@ def sasha(game: Game, player: int, max_depth: int = 6) -> Optional[Tuple[int, in
         else:
             value = float("inf")
             for mx, my in order_moves(g, moves, turn):
-                sim = copy.deepcopy(g)
+                sim = g.copy()
                 sim.make_move(mx, my, turn)
                 value = min(value, alphabeta(sim, depth - 1, alpha, beta, -turn))
                 beta = min(beta, value)
@@ -229,7 +228,7 @@ def sasha(game: Game, player: int, max_depth: int = 6) -> Optional[Tuple[int, in
     for depth in range(1, max_depth + 1):  # iterative deepening
         best_val = -float("inf")
         for x, y in order_moves(game, moves, player):
-            sim = copy.deepcopy(game)
+            sim = game.copy()
             sim.make_move(x, y, player)
             val = alphabeta(sim, depth - 1, -float("inf"), float("inf"), -player)
             if val > best_val:

--- a/backend/game.py
+++ b/backend/game.py
@@ -23,6 +23,23 @@ class Game:
         # moves have been played yet.
         self.last_move: Optional[Tuple[int, int]] = None
 
+    def copy(self) -> "Game":
+        """Return a deep copy of the current game state.
+
+        The game object is small and consists primarily of primitive data
+        structures, so duplicating it manually is significantly faster than
+        using ``copy.deepcopy`` for the thousands of copies performed during
+        bot search.
+        """
+
+        # Bypass ``__init__`` to avoid re-creating the initial board only to
+        # overwrite it immediately.
+        new_game = Game.__new__(Game)
+        new_game.board = [row[:] for row in self.board]
+        new_game.current_player = self.current_player
+        new_game.last_move = self.last_move
+        return new_game
+
     def inside(self, x: int, y: int) -> bool:
         return 0 <= x < BOARD_SIZE and 0 <= y < BOARD_SIZE
 


### PR DESCRIPTION
## Summary
- add Game.copy for fast duplication without deepcopy
- use Game.copy across bots to reduce overhead

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68948edb0e8883278e38868001c3a960