### PR TITLE
Fix Sasha bot initial move when white

### DIFF
--- a/backend/bots.py
+++ b/backend/bots.py
@@ -102,8 +102,8 @@ def sasha(game: Game, player: int, max_depth: int = 6) -> Optional[Tuple[int, in
     total_pieces = sum(abs(cell) for row in game.board for cell in row)
     if total_pieces == 4:  # initial position
         if player == -1:
-            return (2, 3)  # classic opening move for white
-        return (2, 4)  # answer for black
+            return (2, 4)  # classic opening move for white
+        return (2, 3)  # answer for black
 
     opponent = -player
 


### PR DESCRIPTION
## Summary
- Correct Sasha's opening-book move so the white player now chooses a valid first move.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894941198c883278ba8a1ec24bac9de