### PR TITLE
Add variant Sasha bots with adjustable search depth

### DIFF
--- a/backend/bots.py
+++ b/backend/bots.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Callable, Optional, Tuple
+from functools import partial
 
 from .game import Game
 
@@ -241,6 +242,8 @@ BOTS: dict[str, BotStrategy] = {
     "David": david,
     "Roger": roger,
     "Minnie": minnie,
-    "Sasha": sasha,
+    "Sasha senior": sasha,
+    "Sasha junior": partial(sasha, max_depth=5),
+    "Sasha intern": partial(sasha, max_depth=4),
 }
 


### PR DESCRIPTION
## Summary
- expose three Sasha bot variants named senior, junior and intern
- tune each variant's search depth (6, 5, 4) without duplicating core logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894a32ddcc48327841cc73d8dc9d3ef