### PR TITLE
Allow loading saved games during active play

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -366,11 +366,8 @@ class ConnectionManager:
         return True
 
     def load_game(self, game_id: str, data: Dict) -> bool:
-        """Load a saved game state if no players are seated."""
+        """Load a saved game state."""
         if game_id not in self.games:
-            return False
-        players = self.active.get(game_id, {})
-        if players.get("black") or players.get("white"):
             return False
         board = data.get("board")
         current = data.get("current")
@@ -585,7 +582,7 @@ async def websocket_endpoint(websocket: WebSocket, game_id: str):
                     await websocket.send_text(json.dumps({"type": "error", "message": "Cannot stand"}))
             elif action == "load":
                 data = msg.get("data", {})
-                if color is None and manager.load_game(game_id, data):
+                if manager.load_game(game_id, data):
                     game = manager.games[game_id]
                     await manager.broadcast(
                         game_id,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -342,6 +342,28 @@ def test_load_game_updates_board(monkeypatch):
     assert game.last_move == (2, 3)
 
 
+def test_load_game_with_players(monkeypatch):
+    monkeypatch.setattr(
+        ConnectionManager, "_schedule_room_cleanup", lambda self, gid: None
+    )
+    manager = ConnectionManager()
+    gid = manager.create_game()
+    # Simulate both seats being occupied
+    manager.active[gid]["black"] = DummyWebSocket()
+    manager.active[gid]["white"] = DummyWebSocket()
+    snap = {
+        "board": [[0 for _ in range(8)] for _ in range(8)],
+        "current": -1,
+        "last": None,
+    }
+    snap["board"][0][0] = 1
+    assert manager.load_game(gid, snap)
+    game = manager.games[gid]
+    assert game.board[0][0] == 1
+    assert game.current_player == -1
+    assert game.last_move is None
+
+
 def test_stand_up_removes_player_and_bot(monkeypatch):
     async def run_test():
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- Permit `load` websocket action from players or spectators
- Remove seat checks in `load_game`
- Add regression test for loading when seats are occupied

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895fc3bc6748327b1a6cf0a14bbb2c8