### PR TITLE
Convert lobby link to styled button

### DIFF
--- a/static/game.html
+++ b/static/game.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>
-    <a id="back-to-lobby" href="/">Back to Lobby</a>
+    <button id="back-to-lobby">Back to Lobby</button>
     <button id="load-game">Load Game</button>
     <input id="load-file" type="file" style="display:none" />
     <div id="game-wrapper">

--- a/static/script.js
+++ b/static/script.js
@@ -13,6 +13,12 @@ let currentRatings = null;
 let currentSpectators = [];
 const gameId = window.location.pathname.split('/').pop();
 let availableBots = [];
+const backToLobbyBtn = document.getElementById('back-to-lobby');
+if (backToLobbyBtn) {
+    backToLobbyBtn.addEventListener('click', () => {
+        window.location.href = '/';
+    });
+}
 // Track the last move sent by the server so we can highlight it.
 let lastMove = null;
 // History of board states for replay and saving.

--- a/static/styles.css
+++ b/static/styles.css
@@ -7,19 +7,24 @@ body {
     margin: 0;
 }
 
+button {
+    background-color: #654321;
+    color: #fff;
+    border: 2px solid #805a2c;
+    border-radius: 4px;
+    padding: 5px 10px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+button:hover {
+    background-color: #805a2c;
+}
+
 #back-to-lobby {
     position: absolute;
     top: 10px;
     left: 10px;
-    color: #fff;
-    text-decoration: none;
-    background-color: #654321;
-    padding: 5px 10px;
-    border-radius: 4px;
-}
-
-#back-to-lobby:hover {
-    background-color: #805a2c;
 }
 
 #game-wrapper {


### PR DESCRIPTION
## Summary
- replace back-to-lobby anchor with a button element
- add global button styling with thin borders and hover effect to match board theme
- wire back-to-lobby button to navigate to lobby

## Testing
- `pytest` *(fails: AttributeError: 'dict' object has no attribute 'add' in stand_up_removes_player_and_bot)*

------
https://chatgpt.com/codex/tasks/task_e_689733ee7670832799aa62eb0739273b