### PR TITLE
Swap load/save buttons and align player info

### DIFF
--- a/static/game.html
+++ b/static/game.html
@@ -7,21 +7,24 @@
 </head>
 <body>
     <button id="back-to-lobby">Back to Lobby</button>
-    <button id="load-game">Load Game</button>
-    <input id="load-file" type="file" style="display:none" />
     <div id="game-wrapper">
             <h1>Othello</h1>
         <div id="board-container">
             <div id="board-area">
                 <div id="board"></div>
-                <div id="player-info">
-                    <div id="white-player" class="player-row">
-                        <div class="score-circle white"><span id="white-count">0</span></div>
+                <div id="side-panel">
+                    <button id="load-game">Load Game</button>
+                    <button id="save-game" style="display:none">Save Game</button>
+                    <input id="load-file" type="file" style="display:none" />
+                    <div id="player-info">
+                        <div id="white-player" class="player-row">
+                            <div class="score-circle white"><span id="white-count">0</span></div>
                         <span id="white-name"></span> <span id="white-score"></span>
-                    </div>
-                    <div id="black-player" class="player-row">
-                        <div class="score-circle black"><span id="black-count">0</span></div>
+                        </div>
+                        <div id="black-player" class="player-row">
+                            <div class="score-circle black"><span id="black-count">0</span></div>
                         <span id="black-name"></span> <span id="black-score"></span>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/static/script.js
+++ b/static/script.js
@@ -28,6 +28,20 @@ let replayIdx = 0;
 let replayPaused = false;
 let isReplaying = false;
 
+function updateLoadSaveButtons() {
+    const loadBtn = document.getElementById('load-game');
+    const saveBtn = document.getElementById('save-game');
+    if (!loadBtn || !saveBtn) return;
+    const gameStarted = moveHistory.length > 1 || lastMove !== null;
+    if (gameStarted) {
+        loadBtn.style.display = 'none';
+        saveBtn.style.display = 'inline-block';
+    } else {
+        loadBtn.style.display = 'inline-block';
+        saveBtn.style.display = 'none';
+    }
+}
+
 function cloneBoard(board) {
     return board.map(row => row.slice());
 }
@@ -59,6 +73,7 @@ function connect() {
             moveHistory = [{board: cloneBoard(msg.board), current: msg.current, last: msg.last}];
             renderBoard(currentBoard, currentTurn, lastMove);
             renderPlayers(currentPlayers, currentSpectators, currentTurn);
+            updateLoadSaveButtons();
             if (playerName) {
                 socket.send(JSON.stringify({action: 'name', name: playerName}));
             }
@@ -72,12 +87,14 @@ function connect() {
             moveHistory.push({board: cloneBoard(msg.board), current: msg.current, last: msg.last});
             renderBoard(currentBoard, currentTurn, lastMove);
             renderPlayers(currentPlayers, currentSpectators, currentTurn);
+            updateLoadSaveButtons();
         } else if (msg.type === 'players') {
             currentPlayers = msg.players;
             currentTurn = msg.current;
             currentRatings = msg.ratings;
             currentSpectators = msg.spectators || [];
             renderPlayers(currentPlayers, currentSpectators, currentTurn);
+            updateLoadSaveButtons();
         } else if (msg.type === 'chat') {
             appendChat(msg.name, msg.message);
         } else if (msg.type === 'seat') {
@@ -93,6 +110,7 @@ function connect() {
             if (currentPlayers) {
                 renderPlayers(currentPlayers, currentSpectators, currentTurn);
             }
+            updateLoadSaveButtons();
         } else if (msg.type === 'error') {
             alert(msg.message);
         }
@@ -156,11 +174,6 @@ function renderBoard(board, current, last) {
         replayBtn.textContent = 'Replay';
         replayBtn.onclick = startReplay;
         messageDiv.appendChild(replayBtn);
-        messageDiv.appendChild(document.createTextNode(' '));
-        const saveBtn = document.createElement('button');
-        saveBtn.textContent = 'Save Game';
-        saveBtn.onclick = saveGame;
-        messageDiv.appendChild(saveBtn);
         if (playerColor) {
             messageDiv.appendChild(document.createTextNode(' '));
             const btn = document.createElement('button');
@@ -442,6 +455,7 @@ function handleLoadFile(ev) {
                 if (socket) {
                     socket.send(JSON.stringify({action: 'load', data: last}));
                 }
+                updateLoadSaveButtons();
             }
         } catch (err) {
             alert('Invalid file');
@@ -480,6 +494,11 @@ function init() {
         loadBtn.onclick = () => loadInput.click();
         loadInput.addEventListener('change', handleLoadFile);
     }
+    const saveBtn = document.getElementById('save-game');
+    if (saveBtn) {
+        saveBtn.onclick = saveGame;
+    }
+    updateLoadSaveButtons();
 }
 
 window.onload = init;

--- a/static/styles.css
+++ b/static/styles.css
@@ -51,14 +51,26 @@ button:hover {
     margin: 0 auto;
 }
 
-#player-info {
+#side-panel {
     position: absolute;
     top: 8px;
     left: calc(100% + 20px);
+    width: 150px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+}
+
+#player-info {
     display: grid;
     grid-template-rows: repeat(8, 1fr);
     height: 400px;
-    width: 150px;
+    width: 100%;
+}
+
+#load-game,
+#save-game {
+    margin-bottom: 8px;
 }
 
 .player-row {
@@ -69,7 +81,7 @@ button:hover {
 
 #white-name,
 #black-name {
-    flex: 1;
+    margin-right: 4px;
     overflow: hidden;
     text-overflow: ellipsis;
 }
@@ -111,7 +123,7 @@ button:hover {
 
 #white-score,
 #black-score {
-    margin-left: 4px;
+    margin-left: 0;
 }
 
 #message {


### PR DESCRIPTION
## Summary
- Place load/save game controls in a new right-side panel and show save once play begins
- Left-align player names and display ratings directly beside the name

## Testing
- `pytest` *(fails: AttributeError: 'dict' object has no attribute 'add')*

------
https://chatgpt.com/codex/tasks/task_e_68973c8a9c348327972232ce8d4a765f