### PR TITLE
Move standup button to player panel

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -600,7 +600,7 @@ async def websocket_endpoint(websocket: WebSocket, game_id: str):
                 else:
                     await websocket.send_text(json.dumps({"type": "error", "message": "Seat taken"}))
             elif action == "stand":
-                if color and game.current_player == 0 and manager.stand_up(game_id, websocket, color):
+                if color and manager.stand_up(game_id, websocket, color):
                     color = None
                     await websocket.send_text(json.dumps({"type": "seat", "color": None}))
                     await manager.broadcast(
@@ -610,6 +610,7 @@ async def websocket_endpoint(websocket: WebSocket, game_id: str):
                             "players": manager.names[game_id],
                             "current": game.current_player,
                             "ratings": manager.get_game_ratings(game_id),
+                            "spectators": list(manager.watchers.get(game_id, {}).values()),
                         },
                     )
                 else:

--- a/static/script.js
+++ b/static/script.js
@@ -180,11 +180,6 @@ function renderBoard(board, current, last) {
             btn.textContent = 'Restart';
             btn.onclick = sendRestart;
             messageDiv.appendChild(btn);
-            messageDiv.appendChild(document.createTextNode(' '));
-            const standBtn = document.createElement('button');
-            standBtn.textContent = 'Stand Up';
-            standBtn.onclick = sendStand;
-            messageDiv.appendChild(standBtn);
         }
     } else {
         messageDiv.textContent = '';
@@ -205,7 +200,8 @@ function renderPlayers(players, spectators, current) {
         scoreEl.textContent = '';
         if (name) {
             let display = name;
-            if (playerColor === color) {
+            const isYou = playerColor === color;
+            if (isYou) {
                 display += ' (you)';
             }
             const rating = currentRatings && currentRatings[color];
@@ -213,6 +209,14 @@ function renderPlayers(players, spectators, current) {
                 scoreEl.textContent = `(${rating})`;
             }
             nameEl.textContent = display;
+            if (isYou) {
+                const standBtn = document.createElement('button');
+                standBtn.textContent = 'Stand Up';
+                standBtn.onclick = sendStand;
+                standBtn.className = 'stand-button';
+                nameEl.appendChild(document.createTextNode(' '));
+                nameEl.appendChild(standBtn);
+            }
         } else if (!playerColor) {
             const btn = document.createElement('button');
             btn.textContent = 'Sit';

--- a/static/styles.css
+++ b/static/styles.css
@@ -352,3 +352,7 @@ button:hover {
     background-color: rgba(255,255,255,0.2);
     cursor: pointer;
 }
+
+.stand-button {
+    margin-left: 4px;
+}


### PR DESCRIPTION
## Summary
- Keep Stand Up button visible next to the seated player's name
- Remove Stand Up button from game-over message
- Add styling for new Stand Up control

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689887ee01608327b7717e04ec5c6d57